### PR TITLE
json-schema checking for handler settings

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+// Refer to http://json-schema.org/ on how to use JSON Schemas.
+
+const (
+	publicSettingsSchema = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Custom Script - Public Settings",
+    "type": "object",
+    "properties": {
+        "commandToExecute": {
+            "description": "Command to be executed",
+            "type": "string"
+        },
+        "fileUris": {
+            "description": "List of files to be downloaded",
+            "type": "array",
+            "items": {
+                "type": "string",
+				"format": "uri"
+            }
+        },
+		"timestamp": {
+			"description": "An integer, intended to trigger re-execution of the script when changed",
+			"type":"integer" 
+		}
+    },
+	"additionalProperties": false,
+    "required": ["commandToExecute"]
+}`
+
+	protectedSettingsSchema = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Custom Script - Protected Settings",
+    "type": "object",
+    "properties": {
+        "commandToExecute": {
+            "description": "Command to be executed",
+            "type": "string"
+        },
+        "storageAccountName": {
+            "description": "Name of the Azure Storage Account (3-24 characters of lowercase letters or digits)",
+            "type": "string",
+			"pattern": "^[a-z0-9]{3,24}$"
+        },
+		"storageAccountKey": {
+            "description": "Key for the Azure Storage Account (a base64 encoded string)",
+            "type": "string",
+			"pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$"
+        }
+    },
+	"additionalProperties": false
+}`
+)
+
+// validateObjectJSON validates the specified json with schemaJSON.
+// If json is empty string, it will be converted into an empty JSON object
+// before being validated.
+func validateObjectJSON(schema *gojsonschema.Schema, json string) error {
+	if json == "" {
+		json = "{}"
+	}
+
+	doc := gojsonschema.NewStringLoader(json)
+	res, err := schema.Validate(doc)
+	if err != nil {
+		return err
+	}
+	if !res.Valid() {
+		for _, err := range res.Errors() {
+			// return with the first error
+			return fmt.Errorf("%s", err)
+		}
+	}
+	return nil
+}
+
+func validateSettings(settingsType, schemaJSON, docJSON string) error {
+	schema, err := gojsonschema.NewSchema(gojsonschema.NewStringLoader(schemaJSON))
+	if err != nil {
+		return errors.Wrapf(err, "failed to load %s settings schema", settingsType)
+	}
+	if err := validateObjectJSON(schema, docJSON); err != nil {
+		return errors.Wrapf(err, "invalid %s settings JSON", settingsType)
+	}
+	return nil
+}
+
+func validatePublicSettings(json string) error {
+	return validateSettings("public", publicSettingsSchema, json)
+}
+
+func validateProtectedSettings(json string) error {
+	return validateSettings("protected", protectedSettingsSchema, json)
+}

--- a/schema.go
+++ b/schema.go
@@ -11,52 +11,54 @@ import (
 
 const (
 	publicSettingsSchema = `{
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Custom Script - Public Settings",
-    "type": "object",
-    "properties": {
-        "commandToExecute": {
-            "description": "Command to be executed",
-            "type": "string"
-        },
-        "fileUris": {
-            "description": "List of files to be downloaded",
-            "type": "array",
-            "items": {
-                "type": "string",
-				"format": "uri"
-            }
-        },
-		"timestamp": {
-			"description": "An integer, intended to trigger re-execution of the script when changed",
-			"type":"integer" 
-		}
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Custom Script - Public Settings",
+  "type": "object",
+  "properties": {
+    "commandToExecute": {
+      "description": "Command to be executed",
+      "type": "string"
     },
-	"additionalProperties": false,
-    "required": ["commandToExecute"]
+    "fileUris": {
+      "description": "List of files to be downloaded",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
+    },
+    "timestamp": {
+      "description": "An integer, intended to trigger re-execution of the script when changed",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "commandToExecute"
+  ]
 }`
 
 	protectedSettingsSchema = `{
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Custom Script - Protected Settings",
-    "type": "object",
-    "properties": {
-        "commandToExecute": {
-            "description": "Command to be executed",
-            "type": "string"
-        },
-        "storageAccountName": {
-            "description": "Name of the Azure Storage Account (3-24 characters of lowercase letters or digits)",
-            "type": "string",
-			"pattern": "^[a-z0-9]{3,24}$"
-        },
-		"storageAccountKey": {
-            "description": "Key for the Azure Storage Account (a base64 encoded string)",
-            "type": "string",
-			"pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$"
-        }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Custom Script - Protected Settings",
+  "type": "object",
+  "properties": {
+    "commandToExecute": {
+      "description": "Command to be executed",
+      "type": "string"
     },
-	"additionalProperties": false
+    "storageAccountName": {
+      "description": "Name of the Azure Storage Account (3-24 characters of lowercase letters or digits)",
+      "type": "string",
+      "pattern": "^[a-z0-9]{3,24}$"
+    },
+    "storageAccountKey": {
+      "description": "Key for the Azure Storage Account (a base64 encoded string)",
+      "type": "string",
+      "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$"
+    }
+  },
+  "additionalProperties": false
 }`
 )
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -107,7 +107,7 @@ func TestValidateProtectedSettings_storageAccountKey(t *testing.T) {
 	// bad string
 	chkPatternMismatch(validateProtectedSettings(`{"storageAccountKey": "NotABase64Really!"}`), "not b64")
 
-	// missing '=' at the end
+	// for a base64 string ending with '==', removing one of the '=' is not valid b64, the schema validation should catch that
 	chkPatternMismatch(validateProtectedSettings(`{"storageAccountKey": "OllwYfXmC0mSMhWg4x+lUdLg6Eoa/d44+PxPTXBaadO5l87L4JzgkyyVvQr8r60WIzG2X8r6LLxkhNBQaHa3XQ="}`), "bad b64")
 
 	// spacing

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePublicSettings_empty(t *testing.T) {
+	require.NotNil(t, validatePublicSettings(""))
+	require.NotNil(t, validatePublicSettings("{}"))
+}
+
+func TestValidatePublicSettings_missingArgument(t *testing.T) {
+	err := validatePublicSettings(`{"fileUris": ["http://a.b/c.txt"]}`)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "commandToExecute is required")
+}
+
+func TestValidatePublicSettings_hasRequiredArgument_butWrongType(t *testing.T) {
+	err := validatePublicSettings(`{"commandToExecute": ["foo"]}`)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Invalid type. Expected: string, given: array")
+}
+
+func TestValidatePublicSettings_unrecognizedField(t *testing.T) {
+	err := validatePublicSettings(`{"commandToExecute": "date", "alien":0}`)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Additional property alien is not allowed")
+}
+
+func TestValidatePublicSettings_fileUris(t *testing.T) {
+	// empty
+	err := validatePublicSettings(`{"commandToExecute": "date", "fileUris":[]}`)
+	require.Nil(t, err)
+
+	// not a URL
+	err = validatePublicSettings(`{"commandToExecute": "date", "fileUris":["a"]}`)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Does not match format 'uri'")
+
+	// mixed types
+	err = validatePublicSettings(`{"commandToExecute": "date", "fileUris":["https://a.b/c.txt?d=e&f=g", 0]}`)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Expected: string, given: integer")
+}
+
+func TestValidatePublicSettings_timestampSupported(t *testing.T) {
+	require.Nil(t, validatePublicSettings(`{"commandToExecute": "date", "timestamp": 1}`))
+}
+
+func TestValidateProtectedSettings_empty(t *testing.T) {
+	require.Nil(t, validateProtectedSettings(""), "empty string")
+	require.Nil(t, validateProtectedSettings("{}"), "empty string")
+}
+
+func TestValidateProtectedSettings_unrecognizedField(t *testing.T) {
+	err := validateProtectedSettings(`{"alien":0}`)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Additional property alien is not allowed")
+}
+
+func TestValidateProtectedSettings_commandToExecute(t *testing.T) {
+	// Invalid type
+	err := validateProtectedSettings(`{"commandToExecute": false}`)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Expected: string, given: boolean")
+
+	// Valid
+	require.Nil(t, validateProtectedSettings(`{"commandToExecute":"date"}`))
+}
+
+func TestValidateProtectedSettings_storageAccountName(t *testing.T) {
+	chkPatternMismatch := func(e error, reason string) {
+		require.NotNil(t, e, reason)
+		require.Contains(t, e.Error(), "storageAccountName: Does not match pattern", reason)
+	}
+
+	// Specified but empty
+	chkPatternMismatch(validateProtectedSettings(`{"storageAccountName": ""}`), "empty")
+
+	// Too short
+	chkPatternMismatch(validateProtectedSettings(`{"storageAccountName": "aa"}`), "too short")
+
+	// Too long
+	chkPatternMismatch(validateProtectedSettings(`{"storageAccountName": "1234567890123456789012345"}`), "too long")
+
+	// invalid chars
+	chkPatternMismatch(validateProtectedSettings(`{"storageAccountName": "foo-bar"}`), "invalid char")
+	chkPatternMismatch(validateProtectedSettings(`{"storageAccountName": " foobar"}`), "invalid char")
+	chkPatternMismatch(validateProtectedSettings(`{"storageAccountName": "foobar "}`), "invalid char")
+	chkPatternMismatch(validateProtectedSettings(`{"storageAccountName": "foo.bar"}`), "invalid char")
+
+	// ok storage account name
+	require.Nil(t, validateProtectedSettings(`{"storageAccountName": "0foobarquuxyz12345"}`))
+}
+
+func TestValidateProtectedSettings_storageAccountKey(t *testing.T) {
+	chkPatternMismatch := func(e error, reason string) {
+		require.NotNil(t, e, reason)
+		require.Contains(t, e.Error(), "storageAccountKey: Does not match pattern", reason)
+	}
+
+	// empty
+	chkPatternMismatch(validateProtectedSettings(`{"storageAccountKey": ""}`), "empty")
+
+	// bad string
+	chkPatternMismatch(validateProtectedSettings(`{"storageAccountKey": "NotABase64Really!"}`), "not b64")
+
+	// missing '=' at the end
+	chkPatternMismatch(validateProtectedSettings(`{"storageAccountKey": "OllwYfXmC0mSMhWg4x+lUdLg6Eoa/d44+PxPTXBaadO5l87L4JzgkyyVvQr8r60WIzG2X8r6LLxkhNBQaHa3XQ="}`), "bad b64")
+
+	// spacing
+	chkPatternMismatch(validateProtectedSettings(`{"storageAccountKey": "OllwYfXmC0mSMhWg4x+lUdLg6Eoa/d44+PxPTXBaadO5l87L4JzgkyyVvQr8r60WIzG2X8r6LLxkhNBQaHa3XQ== "}`), "whitespace")
+	chkPatternMismatch(validateProtectedSettings(`{"storageAccountKey": " OllwYfXmC0mSMhWg4x+lUdLg6Eoa/d44+PxPTXBaadO5l87L4JzgkyyVvQr8r60WIzG2X8r6LLxkhNBQaHa3XQ=="}`), "whitespace")
+
+	// ok
+	require.Nil(t, validateProtectedSettings(`{"storageAccountKey": "OllwYfXmC0mSMhWg4x+lUdLg6Eoa/d44+PxPTXBaadO5l87L4JzgkyyVvQr8r60WIzG2X8r6LLxkhNBQaHa3XQ=="}`), "ok")
+	require.Nil(t, validateProtectedSettings(`{"storageAccountKey": "A+hMRrsZQ6COPXTYX/EiKiF2HVtfhCfLDo3Dkc3ekKoX3jA58zXVG2QRe/C1+zdEFSrVX6FZsKyivsSlnwmWOw=="}`), "ok")
+	require.Nil(t, validateProtectedSettings(`{"storageAccountKey": "/yGnx6KyxQ8Pjzk0QXeY+66Du0BeTWaCt83la59w72hu/81e6TzskXXvL/IlO3q6g0k0kJrR9MYQNi+cNR3SXA=="}`), "ok")
+}


### PR DESCRIPTION
These utility functions use json-schema (https://tools.ietf.org/html/draft-zyp-json-schema-04)
to validate and if necessary, error out when users specify extra
fields, wrong types, omit required fields etc.

This will save us many validation checks in the code, such as if the required fields are there,
if the inputs match the required format and so on.