### PR TITLE
download: add WithRetries method

### DIFF
--- a/download/downloader_test.go
+++ b/download/downloader_test.go
@@ -13,15 +13,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type badDownloader struct{}
+type badDownloader struct{ calls int }
 
-func (b badDownloader) GetRequest() (*http.Request, error) {
+func (b *badDownloader) GetRequest() (*http.Request, error) {
+	b.calls++
 	return nil, errors.New("expected error")
 }
 
 func TestDownload_wrapsGetRequestError(t *testing.T) {
-	var bd badDownloader
-	_, err := download.Download(bd)
+	_, err := download.Download(new(badDownloader))
 	require.NotNil(t, err)
 	require.EqualError(t, err, "failed to create the request: expected error")
 }

--- a/download/retry.go
+++ b/download/retry.go
@@ -1,0 +1,49 @@
+package download
+
+import (
+	"io"
+	"math"
+	"time"
+)
+
+// SleepFunc pauses the execution for at least duration d.
+type SleepFunc func(d time.Duration)
+
+var (
+	// ActualSleep uses actual time to pause the execution.
+	ActualSleep SleepFunc = time.Sleep
+)
+
+const (
+	// time to sleep between retries is an exponential backoff formula:
+	//   t(n) = k * m^n
+	expRetryN = 7 // how many times we retry the Download
+	expRetryK = time.Second * 5
+	expRetryM = 2
+)
+
+// WithRetries retrieves a response body using the specified downloader. Any
+// error returned from d will be retried (and retrieved response bodies will be
+// closed on failures). If the retries do not succeed, the last error is returned.
+//
+// It sleeps in exponentially increasing durations between retries.
+func WithRetries(d Downloader, sf SleepFunc) (io.ReadCloser, error) {
+	var lastErr error
+	for n := 0; n < expRetryN; n++ {
+		out, err := Download(d)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
+
+		if out != nil { // we are not going to read this response body
+			out.Close()
+		}
+
+		if n != expRetryN-1 {
+			// have more retries to go, sleep before retrying
+			sf(expRetryK * time.Duration(int(math.Pow(float64(expRetryM), float64(n)))))
+		}
+	}
+	return nil, lastErr
+}


### PR DESCRIPTION
WithRetries will retry any download failure and will sleep
in exponentially increasing durations up to 5 min. (5s, 10s,
20s, 40s, 80s, 160s)

The existing extension sleeps a fixed amount and up to 10 minutes.
It also retries all errors (bad host, 404s etc). I kept that part
the same, can be improved with an IsRetryable func later on perhaps.