### PR TITLE
seqnum: sequence number tracking via file

### DIFF
--- a/seqnum/seqnum.go
+++ b/seqnum/seqnum.go
@@ -1,0 +1,39 @@
+// Package seqnum provides utilities to persistently store sequence number in a
+// file and compare against the stored value to ensure a sequence number is
+// processed only once in the extension handler.
+package seqnum
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// chmod is used to set the mode bits for new seqnum files.
+	chmod = os.FileMode(0600)
+)
+
+// Set replaces the stored sequence number in file, or creates a new file at
+// path if it does not exist.
+func Set(path string, num int) error {
+	b := []byte(fmt.Sprintf("%v", num))
+	return errors.Wrap(ioutil.WriteFile(path, b, chmod), "seqnum: failed to write")
+}
+
+// IsSmallerThan returns if the sequence number stored at path is smaller than
+// the provided num. If no number is stored, returns true and no error.
+func IsSmallerThan(path string, num int) (bool, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, errors.Wrap(err, "seqnum: failed to read")
+	}
+	stored, err := strconv.Atoi(string(b))
+	return stored < num, errors.Wrapf(err, "seqnum: cannot parse number %q", b)
+}

--- a/seqnum/seqnum_test.go
+++ b/seqnum/seqnum_test.go
@@ -1,0 +1,88 @@
+package seqnum_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/Azure/custom-script-extension-linux/seqnum"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSet_nonExistingDir(t *testing.T) {
+	err := seqnum.Set("/non/existing/path", 1)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "seqnum: failed to write")
+}
+
+func TestSet_writeFail(t *testing.T) {
+	fp := testFile(t, 0500) // remove read permissions // remove write permissions
+	defer os.RemoveAll(fp)
+
+	err := seqnum.Set(fp, 0)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "seqnum: failed to write")
+}
+
+func TestSet(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	require.Nil(t, err)
+	f.Close()
+	fp := f.Name()
+	defer os.RemoveAll(fp)
+
+	require.Nil(t, seqnum.Set(fp, 1))
+}
+
+func TestSetGet(t *testing.T) {
+	fp := testFile(t, 0600)
+	defer os.RemoveAll(fp)
+
+	require.Nil(t, seqnum.Set(fp, 1))
+
+	b, err := seqnum.IsSmallerThan(fp, 2)
+	require.Nil(t, err)
+	require.True(t, b, "1<2")
+
+	b, err = seqnum.IsSmallerThan(fp, 1)
+	require.Nil(t, err)
+	require.False(t, b, "1≮1")
+
+	b, err = seqnum.IsSmallerThan(fp, 0)
+	require.Nil(t, err)
+	require.False(t, b, "1≮0")
+}
+
+func TestIsSmallerThan_nonExistingFile(t *testing.T) {
+	b, err := seqnum.IsSmallerThan("/non/existing/path", 0)
+	require.Nil(t, err)
+	require.True(t, b, "non-existing file is always smaller than specified seqnum")
+}
+
+func TestIsSmallerThan_readFailure(t *testing.T) {
+	fp := testFile(t, 0100) // remove read permissions
+	defer os.RemoveAll(fp)
+
+	_, err := seqnum.IsSmallerThan(fp, 0)
+	require.NotNil(t, err, "read should have failed")
+	require.Contains(t, err.Error(), "seqnum: failed to read")
+}
+
+func TestIsSmallerThan_parseError(t *testing.T) {
+	fp := testFile(t, 0600)
+	defer os.RemoveAll(fp)
+
+	require.Nil(t, ioutil.WriteFile(fp, []byte{'a'}, 0700))
+
+	_, err := seqnum.IsSmallerThan(fp, 0)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "seqnum: cannot parse number \"a\"")
+}
+
+func testFile(t *testing.T, mode os.FileMode) string {
+	f, err := ioutil.TempFile("", "")
+	require.Nil(t, err, "creating test file failed")
+	require.Nil(t, f.Chmod(mode), "chmod test file failed")
+	require.Nil(t, f.Close(), "failed to close test file")
+	return f.Name()
+}

--- a/seqnum/seqnum_test.go
+++ b/seqnum/seqnum_test.go
@@ -24,7 +24,7 @@ func TestSet_writeFail(t *testing.T) {
 	require.Contains(t, err.Error(), "seqnum: failed to write")
 }
 
-func TestSet(t *testing.T) {
+func TestSet_newFile(t *testing.T) {
 	f, err := ioutil.TempFile("", "")
 	require.Nil(t, err)
 	f.Close()
@@ -32,6 +32,31 @@ func TestSet(t *testing.T) {
 	defer os.RemoveAll(fp)
 
 	require.Nil(t, seqnum.Set(fp, 1))
+
+	// validate contents
+	b, err := ioutil.ReadFile(fp)
+	require.Nil(t, err)
+	require.Equal(t, "1", string(b))
+
+	// validate chmod
+	fi, err := os.Stat(fp)
+	require.Nil(t, err)
+	require.EqualValues(t, os.FileMode(0600).String(), fi.Mode().String())
+}
+
+func TestSet_truncates(t *testing.T) {
+	f, err := ioutil.TempFile("", "")
+	require.Nil(t, err)
+	f.Close()
+	fp := f.Name()
+	defer os.RemoveAll(fp)
+
+	require.Nil(t, seqnum.Set(fp, 1))
+	require.Nil(t, seqnum.Set(fp, 2))
+
+	b, err := ioutil.ReadFile(fp)
+	require.Nil(t, err)
+	require.Equal(t, "2", string(b))
 }
 
 func TestSetGet(t *testing.T) {


### PR DESCRIPTION
I gave a thought about using/extending docker-extension's
seqnumfile pkg but it has some hardcoded stuff and designed to
prevent executing the sequence number simultaneously.

This code is shorter and exposes only methods to make sure
we only process sequence numbers greater than the stored one.