### PR TITLE
download/retry: reduce retry duration

### DIFF
--- a/download/retry.go
+++ b/download/retry.go
@@ -18,7 +18,7 @@ const (
 	// time to sleep between retries is an exponential backoff formula:
 	//   t(n) = k * m^n
 	expRetryN = 7 // how many times we retry the Download
-	expRetryK = time.Second * 5
+	expRetryK = time.Second * 3
 	expRetryM = 2
 )
 

--- a/download/retry_test.go
+++ b/download/retry_test.go
@@ -14,12 +14,12 @@ import (
 var (
 	// how much we sleep between retries
 	sleepSchedule = []time.Duration{
-		5 * time.Second,
-		10 * time.Second,
-		20 * time.Second,
-		40 * time.Second,
-		80 * time.Second,
-		160 * time.Second}
+		3 * time.Second,
+		6 * time.Second,
+		12 * time.Second,
+		24 * time.Second,
+		48 * time.Second,
+		96 * time.Second}
 )
 
 func TestActualSleep_actuallySleeps(t *testing.T) {


### PR DESCRIPTION
the old agent retries constant time for 10*20s=200s. modifying
this to retry for total 189s. to be closer to 3 minutes instead
of minutes.