### PR TITLE
Vendor: github.com/Azure/azure-docker-extension

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -8,13 +8,18 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/Azure/azure-docker-extension/pkg/executil",
-			"Comment": "1.1.1606092330-4-gbd96e18",
-			"Rev": "bd96e1834b13a7f7d86a21692d97c87b35d196a3"
+			"Comment": "1.1.1606092330-10-gb8a99a4",
+			"Rev": "b8a99a4c8a1065e53b053f01224818980a7022b7"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-docker-extension/pkg/vmextension",
-			"Comment": "1.1.1606092330-4-gbd96e18",
-			"Rev": "bd96e1834b13a7f7d86a21692d97c87b35d196a3"
+			"Comment": "1.1.1606092330-10-gb8a99a4",
+			"Rev": "b8a99a4c8a1065e53b053f01224818980a7022b7"
+		},
+		{
+			"ImportPath": "github.com/Azure/azure-docker-extension/pkg/vmextension/status",
+			"Comment": "1.1.1606092330-10-gb8a99a4",
+			"Rev": "b8a99a4c8a1065e53b053f01224818980a7022b7"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/storage",

--- a/vendor/github.com/Azure/azure-docker-extension/pkg/vmextension/handlerenv.go
+++ b/vendor/github.com/Azure/azure-docker-extension/pkg/vmextension/handlerenv.go
@@ -3,8 +3,18 @@ package vmextension
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
+// HandlerEnvFileName is the file name of the Handler Environment as placed by the
+// Azure Linux Guest Agent.
+const HandlerEnvFileName = "HandlerEnvironment.json"
+
+// HandlerEnvironment describes the handler environment configuration presented
+// to the extension handler by the Azure Linux Guest Agent.
 type HandlerEnvironment struct {
 	Version            float64 `json:"version"`
 	SeqNo              string  `json:"seqNo"`
@@ -17,18 +27,53 @@ type HandlerEnvironment struct {
 	}
 }
 
-type HandlerEnvironmentFile []HandlerEnvironment
+// GetHandlerEnv locates the HandlerEnvironment.json file by assuming it lives
+// next to or one level above the extension handler (read: this) executable,
+// reads, parses and returns it.
+func GetHandlerEnv() (he HandlerEnvironment, _ error) {
+	dir, err := scriptDir()
+	if err != nil {
+		return he, fmt.Errorf("vmextension: cannot find base directory of the running process: %v", err)
+	}
+	paths := []string{
+		filepath.Join(dir, HandlerEnvFileName),       // this level (i.e. executable is in [EXT_NAME]/.)
+		filepath.Join(dir, "..", HandlerEnvFileName), // one up (i.e. executable is in [EXT_NAME]/bin/.)
+	}
+	var b []byte
+	for _, p := range paths {
+		o, err := ioutil.ReadFile(p)
+		if err != nil && !os.IsNotExist(err) {
+			return he, fmt.Errorf("vmextension: error examining HandlerEnvironment at '%s': %v", p, err)
+		} else if err == nil {
+			b = o
+			break
+		}
+	}
+	if b == nil {
+		return he, fmt.Errorf("vmextension: Cannot find HandlerEnvironment at paths: %s", strings.Join(paths, ", "))
+	}
+	return ParseHandlerEnv(b)
+}
 
-// ParseHandlerEnv parses the /var/lib/waagent/[extension]/HandlerEnvironment.json
-// format.
-func ParseHandlerEnv(b []byte) (HandlerEnvironment, error) {
-	var hf HandlerEnvironmentFile
-	var he HandlerEnvironment
+// scriptDir returns the absolute path of the running process.
+func scriptDir() (string, error) {
+	p, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(p), nil
+}
+
+// ParseHandlerEnv parses the
+// /var/lib/waagent/[extension]/HandlerEnvironment.json format.
+func ParseHandlerEnv(b []byte) (he HandlerEnvironment, _ error) {
+	var hf []HandlerEnvironment
+
 	if err := json.Unmarshal(b, &hf); err != nil {
-		return he, fmt.Errorf("failed to parse handler env: %v", err)
+		return he, fmt.Errorf("vmextension: failed to parse handler env: %v", err)
 	}
 	if len(hf) != 1 {
-		return he, fmt.Errorf("expected 1 config in HandlerEnvironment, found: %v", len(hf))
+		return he, fmt.Errorf("vmextension: expected 1 config in parsed HandlerEnvironment, found: %v", len(hf))
 	}
 	return hf[0], nil
 }

--- a/vendor/github.com/Azure/azure-docker-extension/pkg/vmextension/status/status.go
+++ b/vendor/github.com/Azure/azure-docker-extension/pkg/vmextension/status/status.go
@@ -1,0 +1,68 @@
+package status
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"time"
+)
+
+type StatusReport []StatusItem
+
+type StatusItem struct {
+	Version      float64 `json:"version"`
+	TimestampUTC string  `json:"timestampUTC"`
+	Status       Status  `json:"status"`
+}
+
+type Type string
+
+const (
+	StatusTransitioning Type = "transitioning"
+	StatusError         Type = "error"
+	StatusSuccess       Type = "success"
+)
+
+type Status struct {
+	Operation        string           `json:"operation"`
+	Status           Type             `json:"status"`
+	FormattedMessage FormattedMessage `json:"formattedMessage"`
+}
+type FormattedMessage struct {
+	Lang    string `json:"lang"`
+	Message string `json:"message"`
+}
+
+func NewStatus(t Type, operation, message string) StatusReport {
+	return []StatusItem{
+		{
+			Version:      1.0,
+			TimestampUTC: time.Now().UTC().Format(time.RFC3339),
+			Status: Status{
+				Operation: operation,
+				Status:    t,
+				FormattedMessage: FormattedMessage{
+					Lang:    "en",
+					Message: message},
+			},
+		},
+	}
+}
+
+func (r StatusReport) marshal() ([]byte, error) {
+	return json.MarshalIndent(r, "", "\t")
+}
+
+// Save persists the status message to the specified status folder
+// using the sequence number.
+func (r StatusReport) Save(statusFolder string, seqNum int) error {
+	fn := fmt.Sprintf("%d.status", seqNum)
+	fp := filepath.Join(statusFolder, fn)
+
+	b, err := r.marshal()
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(fp, b, 0644)
+}


### PR DESCRIPTION
Vendor-only change.


Incorporate latest changes (PRs 96, 97, 98) from azure-docker-extension repo
where we grab extension handler authoring utility pkgs for Go.

Highlights:

- Cut the dependency to the `github.com/Azure/azure-docker-extension/pkg/executil`
- Added `pkg/vmextension/status` for utilities to report handler status.

Signed-off-by: Ahmet Alp Balkan