### PR TITLE
Vendor logging dependencies

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -30,6 +30,21 @@
 			"Rev": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
 		},
 		{
+			"ImportPath": "github.com/go-kit/kit/log",
+			"Comment": "v0.1.0-64-gb076b44",
+			"Rev": "b076b44dbec2aa943b52c9efaa5e8b46fd52b061"
+		},
+		{
+			"ImportPath": "github.com/go-logfmt/logfmt",
+			"Comment": "v0.2.0-9-gd432719",
+			"Rev": "d4327190ff838312623b09bfeb50d7c93c8d9c1d"
+		},
+		{
+			"ImportPath": "github.com/go-stack/stack",
+			"Comment": "v1.5.2",
+			"Rev": "100eb0c0a9c5b306ca2fb4f165df21d80ada4b82"
+		},
+		{
 			"ImportPath": "github.com/gorilla/context",
 			"Comment": "v1.1-4-gaed02d1",
 			"Rev": "aed02d124ae4a0e94fea4541c8effd05bf0c8296"
@@ -38,6 +53,10 @@
 			"ImportPath": "github.com/gorilla/mux",
 			"Comment": "v1.1-13-g9fa818a",
 			"Rev": "9fa818a44c2bf1396a17f9d5a3c0f6dd39d2ff8e"
+		},
+		{
+			"ImportPath": "github.com/kr/logfmt",
+			"Rev": "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 		},
 		{
 			"ImportPath": "github.com/pkg/errors",

--- a/vendor/github.com/go-kit/kit/LICENSE
+++ b/vendor/github.com/go-kit/kit/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Peter Bourgon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/go-kit/kit/log/README.md
+++ b/vendor/github.com/go-kit/kit/log/README.md
@@ -1,0 +1,148 @@
+# package log
+
+`package log` provides a minimal interface for structured logging in services.
+It may be wrapped to encode conventions, enforce type-safety, provide leveled logging, and so on.
+It can be used for both typical application log events, and log-structured data streams.
+
+## Structured logging
+
+Structured logging is, basically, conceding to the reality that logs are _data_,
+ and warrant some level of schematic rigor.
+Using a stricter, key/value-oriented message format for our logs,
+ containing contextual and semantic information,
+ makes it much easier to get insight into the operational activity of the systems we build.
+Consequently, `package log` is of the strong belief that
+ "[the benefits of structured logging outweigh the minimal effort involved](https://www.thoughtworks.com/radar/techniques/structured-logging)".
+
+Migrating from unstructured to structured logging is probably a lot easier than you'd expect.
+
+```go
+// Unstructured
+log.Printf("HTTP server listening on %s", addr)
+
+// Structured
+logger.Log("transport", "HTTP", "addr", addr, "msg", "listening")
+```
+
+## Usage
+
+### Typical application logging
+
+```go
+w := log.NewSyncWriter(os.Stderr)
+logger := log.NewLogfmtLogger(w)
+logger.Log("question", "what is the meaning of life?", "answer", 42)
+
+// Output:
+// question="what is the meaning of life?" answer=42
+```
+
+### Log contexts
+
+```go
+func main() {
+	var logger log.Logger
+	logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	logger = log.NewContext(logger).With("instance_id", 123)
+
+	logger.Log("msg", "starting")
+	NewWorker(log.NewContext(logger).With("component", "worker")).Run()
+	NewSlacker(log.NewContext(logger).With("component", "slacker")).Run()
+}
+
+// Output:
+// instance_id=123 msg=starting
+// instance_id=123 component=worker msg=running
+// instance_id=123 component=slacker msg=running
+```
+
+### Interact with stdlib logger
+
+Redirect stdlib logger to Go kit logger.
+
+```go
+import (
+	"os"
+	stdlog "log"
+	kitlog "github.com/go-kit/kit/log"
+)
+
+func main() {
+	logger := kitlog.NewJSONLogger(log.NewSyncWriter(os.Stdout))
+	stdlog.SetOutput(kitlog.NewStdlibAdapter(logger))
+	stdlog.Print("I sure like pie")
+}
+
+// Output:
+// {"msg":"I sure like pie","ts":"2016/01/01 12:34:56"}
+```
+
+Or, if, for legacy reasons,
+ you need to pipe all of your logging through the stdlib log package,
+ you can redirect Go kit logger to the stdlib logger.
+
+```go
+logger := kitlog.NewLogfmtLogger(kitlog.StdlibWriter{})
+logger.Log("legacy", true, "msg", "at least it's something")
+
+// Output:
+// 2016/01/01 12:34:56 legacy=true msg="at least it's something"
+```
+
+### Timestamps and callers
+
+```go
+var logger log.Logger
+logger = log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+logger = log.NewContext(logger).With("ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
+
+logger.Log("msg", "hello")
+
+// Output:
+// ts=2016-01-01T12:34:56Z caller=main.go:15 msg=hello
+```
+
+## Supported output formats
+
+- [Logfmt](https://brandur.org/logfmt)
+- JSON
+
+## Enhancements
+
+`package log` is centered on the one-method Logger interface.
+
+```go
+type Logger interface {
+	Log(keyvals ...interface{}) error
+}
+```
+
+This interface, and its supporting code like [log.Context](https://godoc.org/github.com/go-kit/kit/log#Context),
+ is the product of much iteration and evaluation.
+For more details on the evolution of the Logger interface,
+ see [The Hunt for a Logger Interface](http://go-talks.appspot.com/github.com/ChrisHines/talks/structured-logging/structured-logging.slide#1),
+ a talk by [Chris Hines](https://github.com/ChrisHines).
+Also, please see
+ [#63](https://github.com/go-kit/kit/issues/63),
+ [#76](https://github.com/go-kit/kit/pull/76),
+ [#131](https://github.com/go-kit/kit/issues/131),
+ [#157](https://github.com/go-kit/kit/pull/157),
+ [#164](https://github.com/go-kit/kit/issues/164), and
+ [#252](https://github.com/go-kit/kit/pull/252)
+ to review historical conversations about package log and the Logger interface.
+
+Value-add packages and suggestions,
+ like improvements to [the leveled logger](https://godoc.org/github.com/go-kit/kit/log/levels),
+ are of course welcome.
+Good proposals should
+
+- Be composable with [log.Context](https://godoc.org/github.com/go-kit/kit/log#Context),
+- Not break the behavior of [log.Caller](https://godoc.org/github.com/go-kit/kit/log#Caller) in any wrapped context, and
+- Be friendly to packages that accept only an unadorned log.Logger.
+
+## Benchmarks & comparisons
+
+There are a few Go logging benchmarks and comparisons that include Go kit's package log.
+
+- [imkira/go-loggers-bench](https://github.com/imkira/go-loggers-bench) includes kit/log
+- [uber-common/zap](https://github.com/uber-common/zap), a zero-alloc logging library, includes a comparison with kit/log

--- a/vendor/github.com/go-kit/kit/log/doc.go
+++ b/vendor/github.com/go-kit/kit/log/doc.go
@@ -1,0 +1,93 @@
+// Package log provides a structured logger.
+//
+// Structured logging produces logs easily consumed later by humans or
+// machines. Humans might be interested in debugging errors, or tracing
+// specific requests. Machines might be interested in counting interesting
+// events, or aggregating information for off-line processing. In both cases,
+// it is important that the log messages are structured and actionable.
+// Package log is designed to encourage both of these best practices.
+//
+// Basic Usage
+//
+// The fundamental interface is Logger. Loggers create log events from
+// key/value data. The Logger interface has a single method, Log, which
+// accepts a sequence of alternating key/value pairs, which this package names
+// keyvals.
+//
+//    type Logger interface {
+//        Log(keyvals ...interface{}) error
+//    }
+//
+// Here is an example of a function using a Logger to create log events.
+//
+//    func RunTask(task Task, logger log.Logger) string {
+//        logger.Log("taskID", task.ID, "event", "starting task")
+//        ...
+//        logger.Log("taskID", task.ID, "event", "task complete")
+//    }
+//
+// The keys in the above example are "taskID" and "event". The values are
+// task.ID, "starting task", and "task complete". Every key is followed
+// immediately by its value.
+//
+// Keys are usually plain strings. Values may be any type that has a sensible
+// encoding in the chosen log format. With structured logging it is a good
+// idea to log simple values without formatting them. This practice allows
+// the chosen logger to encode values in the most appropriate way.
+//
+// Log Context
+//
+// A log context stores keyvals that it includes in all log events. Building
+// appropriate log contexts reduces repetition and aids consistency in the
+// resulting log output. We can use a context to improve the RunTask example.
+//
+//    func RunTask(task Task, logger log.Logger) string {
+//        logger = log.NewContext(logger).With("taskID", task.ID)
+//        logger.Log("event", "starting task")
+//        ...
+//        taskHelper(task.Cmd, logger)
+//        ...
+//        logger.Log("event", "task complete")
+//    }
+//
+// The improved version emits the same log events as the original for the
+// first and last calls to Log. The call to taskHelper highlights that a
+// context may be passed as a logger to other functions. Each log event
+// created by the called function will include the task.ID even though the
+// function does not have access to that value. Using log contexts this way
+// simplifies producing log output that enables tracing the life cycle of
+// individual tasks. (See the Context example for the full code of the
+// above snippet.)
+//
+// Dynamic Context Values
+//
+// A Valuer function stored in a log context generates a new value each time
+// the context logs an event. The Valuer example demonstrates how this
+// feature works.
+//
+// Valuers provide the basis for consistently logging timestamps and source
+// code location. The log package defines several valuers for that purpose.
+// See Timestamp, DefaultTimestamp, DefaultTimestampUTC, Caller, and
+// DefaultCaller. A common logger initialization sequence that ensures all log
+// entries contain a timestamp and source location looks like this:
+//
+//    logger := log.NewLogfmtLogger(log.SyncWriter(os.Stdout))
+//    logger = log.NewContext(logger).With("ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
+//
+// Concurrent Safety
+//
+// Applications with multiple goroutines want each log event written to the
+// same logger to remain separate from other log events. Package log provides
+// two simple solutions for concurrent safe logging.
+//
+// NewSyncWriter wraps an io.Writer and serializes each call to its Write
+// method. Using a SyncWriter has the benefit that the smallest practical
+// portion of the logging logic is performed within a mutex, but it requires
+// the formatting Logger to make only one call to Write per log event.
+//
+// NewSyncLogger wraps any Logger and serializes each call to its Log method.
+// Using a SyncLogger has the benefit that it guarantees each log event is
+// handled atomically within the wrapped logger, but it typically serializes
+// both the formatting and output logic. Use a SyncLogger if the formatting
+// logger may perform multiple writes per log event.
+package log

--- a/vendor/github.com/go-kit/kit/log/json_logger.go
+++ b/vendor/github.com/go-kit/kit/log/json_logger.go
@@ -1,0 +1,92 @@
+package log
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+)
+
+type jsonLogger struct {
+	io.Writer
+}
+
+// NewJSONLogger returns a Logger that encodes keyvals to the Writer as a
+// single JSON object. Each log event produces no more than one call to
+// w.Write. The passed Writer must be safe for concurrent use by multiple
+// goroutines if the returned Logger will be used concurrently.
+func NewJSONLogger(w io.Writer) Logger {
+	return &jsonLogger{w}
+}
+
+func (l *jsonLogger) Log(keyvals ...interface{}) error {
+	n := (len(keyvals) + 1) / 2 // +1 to handle case when len is odd
+	m := make(map[string]interface{}, n)
+	for i := 0; i < len(keyvals); i += 2 {
+		k := keyvals[i]
+		var v interface{} = ErrMissingValue
+		if i+1 < len(keyvals) {
+			v = keyvals[i+1]
+		}
+		merge(m, k, v)
+	}
+	return json.NewEncoder(l.Writer).Encode(m)
+}
+
+func merge(dst map[string]interface{}, k, v interface{}) {
+	var key string
+	switch x := k.(type) {
+	case string:
+		key = x
+	case fmt.Stringer:
+		key = safeString(x)
+	default:
+		key = fmt.Sprint(x)
+	}
+	if x, ok := v.(error); ok {
+		v = safeError(x)
+	}
+
+	// We want json.Marshaler and encoding.TextMarshaller to take priority over
+	// err.Error() and v.String(). But json.Marshall (called later) does that by
+	// default so we force a no-op if it's one of those 2 case.
+	switch x := v.(type) {
+	case json.Marshaler:
+	case encoding.TextMarshaler:
+	case error:
+		v = safeError(x)
+	case fmt.Stringer:
+		v = safeString(x)
+	}
+
+	dst[key] = v
+}
+
+func safeString(str fmt.Stringer) (s string) {
+	defer func() {
+		if panicVal := recover(); panicVal != nil {
+			if v := reflect.ValueOf(str); v.Kind() == reflect.Ptr && v.IsNil() {
+				s = "NULL"
+			} else {
+				panic(panicVal)
+			}
+		}
+	}()
+	s = str.String()
+	return
+}
+
+func safeError(err error) (s interface{}) {
+	defer func() {
+		if panicVal := recover(); panicVal != nil {
+			if v := reflect.ValueOf(err); v.Kind() == reflect.Ptr && v.IsNil() {
+				s = nil
+			} else {
+				panic(panicVal)
+			}
+		}
+	}()
+	s = err.Error()
+	return
+}

--- a/vendor/github.com/go-kit/kit/log/log.go
+++ b/vendor/github.com/go-kit/kit/log/log.go
@@ -1,0 +1,144 @@
+package log
+
+import "errors"
+
+// Logger is the fundamental interface for all log operations. Log creates a
+// log event from keyvals, a variadic sequence of alternating keys and values.
+// Implementations must be safe for concurrent use by multiple goroutines. In
+// particular, any implementation of Logger that appends to keyvals or
+// modifies any of its elements must make a copy first.
+type Logger interface {
+	Log(keyvals ...interface{}) error
+}
+
+// ErrMissingValue is appended to keyvals slices with odd length to substitute
+// the missing value.
+var ErrMissingValue = errors.New("(MISSING)")
+
+// NewContext returns a new Context that logs to logger.
+func NewContext(logger Logger) *Context {
+	if c, ok := logger.(*Context); ok {
+		return c
+	}
+	return &Context{logger: logger}
+}
+
+// Context must always have the same number of stack frames between calls to
+// its Log method and the eventual binding of Valuers to their value. This
+// requirement comes from the functional requirement to allow a context to
+// resolve application call site information for a log.Caller stored in the
+// context. To do this we must be able to predict the number of logging
+// functions on the stack when bindValues is called.
+//
+// Three implementation details provide the needed stack depth consistency.
+// The first two of these details also result in better amortized performance,
+// and thus make sense even without the requirements regarding stack depth.
+// The third detail, however, is subtle and tied to the implementation of the
+// Go compiler.
+//
+//    1. NewContext avoids introducing an additional layer when asked to
+//       wrap another Context.
+//    2. With avoids introducing an additional layer by returning a newly
+//       constructed Context with a merged keyvals rather than simply
+//       wrapping the existing Context.
+//    3. All of Context's methods take pointer receivers even though they
+//       do not mutate the Context.
+//
+// Before explaining the last detail, first some background. The Go compiler
+// generates wrapper methods to implement the auto dereferencing behavior when
+// calling a value method through a pointer variable. These wrapper methods
+// are also used when calling a value method through an interface variable
+// because interfaces store a pointer to the underlying concrete value.
+// Calling a pointer receiver through an interface does not require generating
+// an additional function.
+//
+// If Context had value methods then calling Context.Log through a variable
+// with type Logger would have an extra stack frame compared to calling
+// Context.Log through a variable with type Context. Using pointer receivers
+// avoids this problem.
+
+// A Context wraps a Logger and holds keyvals that it includes in all log
+// events. When logging, a Context replaces all value elements (odd indexes)
+// containing a Valuer with their generated value for each call to its Log
+// method.
+type Context struct {
+	logger    Logger
+	keyvals   []interface{}
+	hasValuer bool
+}
+
+// Log replaces all value elements (odd indexes) containing a Valuer in the
+// stored context with their generated value, appends keyvals, and passes the
+// result to the wrapped Logger.
+func (l *Context) Log(keyvals ...interface{}) error {
+	kvs := append(l.keyvals, keyvals...)
+	if len(kvs)%2 != 0 {
+		kvs = append(kvs, ErrMissingValue)
+	}
+	if l.hasValuer {
+		// If no keyvals were appended above then we must copy l.keyvals so
+		// that future log events will reevaluate the stored Valuers.
+		if len(keyvals) == 0 {
+			kvs = append([]interface{}{}, l.keyvals...)
+		}
+		bindValues(kvs[:len(l.keyvals)])
+	}
+	return l.logger.Log(kvs...)
+}
+
+// With returns a new Context with keyvals appended to those of the receiver.
+func (l *Context) With(keyvals ...interface{}) *Context {
+	if len(keyvals) == 0 {
+		return l
+	}
+	kvs := append(l.keyvals, keyvals...)
+	if len(kvs)%2 != 0 {
+		kvs = append(kvs, ErrMissingValue)
+	}
+	return &Context{
+		logger: l.logger,
+		// Limiting the capacity of the stored keyvals ensures that a new
+		// backing array is created if the slice must grow in Log or With.
+		// Using the extra capacity without copying risks a data race that
+		// would violate the Logger interface contract.
+		keyvals:   kvs[:len(kvs):len(kvs)],
+		hasValuer: l.hasValuer || containsValuer(keyvals),
+	}
+}
+
+// WithPrefix returns a new Context with keyvals prepended to those of the
+// receiver.
+func (l *Context) WithPrefix(keyvals ...interface{}) *Context {
+	if len(keyvals) == 0 {
+		return l
+	}
+	// Limiting the capacity of the stored keyvals ensures that a new
+	// backing array is created if the slice must grow in Log or With.
+	// Using the extra capacity without copying risks a data race that
+	// would violate the Logger interface contract.
+	n := len(l.keyvals) + len(keyvals)
+	if len(keyvals)%2 != 0 {
+		n++
+	}
+	kvs := make([]interface{}, 0, n)
+	kvs = append(kvs, keyvals...)
+	if len(kvs)%2 != 0 {
+		kvs = append(kvs, ErrMissingValue)
+	}
+	kvs = append(kvs, l.keyvals...)
+	return &Context{
+		logger:    l.logger,
+		keyvals:   kvs,
+		hasValuer: l.hasValuer || containsValuer(keyvals),
+	}
+}
+
+// LoggerFunc is an adapter to allow use of ordinary functions as Loggers. If
+// f is a function with the appropriate signature, LoggerFunc(f) is a Logger
+// object that calls f.
+type LoggerFunc func(...interface{}) error
+
+// Log implements Logger by calling f(keyvals...).
+func (f LoggerFunc) Log(keyvals ...interface{}) error {
+	return f(keyvals...)
+}

--- a/vendor/github.com/go-kit/kit/log/logfmt_logger.go
+++ b/vendor/github.com/go-kit/kit/log/logfmt_logger.go
@@ -1,0 +1,62 @@
+package log
+
+import (
+	"bytes"
+	"io"
+	"sync"
+
+	"github.com/go-logfmt/logfmt"
+)
+
+type logfmtEncoder struct {
+	*logfmt.Encoder
+	buf bytes.Buffer
+}
+
+func (l *logfmtEncoder) Reset() {
+	l.Encoder.Reset()
+	l.buf.Reset()
+}
+
+var logfmtEncoderPool = sync.Pool{
+	New: func() interface{} {
+		var enc logfmtEncoder
+		enc.Encoder = logfmt.NewEncoder(&enc.buf)
+		return &enc
+	},
+}
+
+type logfmtLogger struct {
+	w io.Writer
+}
+
+// NewLogfmtLogger returns a logger that encodes keyvals to the Writer in
+// logfmt format. Each log event produces no more than one call to w.Write.
+// The passed Writer must be safe for concurrent use by multiple goroutines if
+// the returned Logger will be used concurrently.
+func NewLogfmtLogger(w io.Writer) Logger {
+	return &logfmtLogger{w}
+}
+
+func (l logfmtLogger) Log(keyvals ...interface{}) error {
+	enc := logfmtEncoderPool.Get().(*logfmtEncoder)
+	enc.Reset()
+	defer logfmtEncoderPool.Put(enc)
+
+	if err := enc.EncodeKeyvals(keyvals...); err != nil {
+		return err
+	}
+
+	// Add newline to the end of the buffer
+	if err := enc.EndRecord(); err != nil {
+		return err
+	}
+
+	// The Logger interface requires implementations to be safe for concurrent
+	// use by multiple goroutines. For this implementation that means making
+	// only one call to l.w.Write() for each call to Log.
+	if _, err := l.w.Write(enc.buf.Bytes()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/go-kit/kit/log/nop_logger.go
+++ b/vendor/github.com/go-kit/kit/log/nop_logger.go
@@ -1,0 +1,8 @@
+package log
+
+type nopLogger struct{}
+
+// NewNopLogger returns a logger that doesn't do anything.
+func NewNopLogger() Logger { return nopLogger{} }
+
+func (nopLogger) Log(...interface{}) error { return nil }

--- a/vendor/github.com/go-kit/kit/log/stdlib.go
+++ b/vendor/github.com/go-kit/kit/log/stdlib.go
@@ -1,0 +1,116 @@
+package log
+
+import (
+	"io"
+	"log"
+	"regexp"
+	"strings"
+)
+
+// StdlibWriter implements io.Writer by invoking the stdlib log.Print. It's
+// designed to be passed to a Go kit logger as the writer, for cases where
+// it's necessary to redirect all Go kit log output to the stdlib logger.
+//
+// If you have any choice in the matter, you shouldn't use this. Prefer to
+// redirect the stdlib log to the Go kit logger via NewStdlibAdapter.
+type StdlibWriter struct{}
+
+// Write implements io.Writer.
+func (w StdlibWriter) Write(p []byte) (int, error) {
+	log.Print(strings.TrimSpace(string(p)))
+	return len(p), nil
+}
+
+// StdlibAdapter wraps a Logger and allows it to be passed to the stdlib
+// logger's SetOutput. It will extract date/timestamps, filenames, and
+// messages, and place them under relevant keys.
+type StdlibAdapter struct {
+	Logger
+	timestampKey string
+	fileKey      string
+	messageKey   string
+}
+
+// StdlibAdapterOption sets a parameter for the StdlibAdapter.
+type StdlibAdapterOption func(*StdlibAdapter)
+
+// TimestampKey sets the key for the timestamp field. By default, it's "ts".
+func TimestampKey(key string) StdlibAdapterOption {
+	return func(a *StdlibAdapter) { a.timestampKey = key }
+}
+
+// FileKey sets the key for the file and line field. By default, it's "file".
+func FileKey(key string) StdlibAdapterOption {
+	return func(a *StdlibAdapter) { a.fileKey = key }
+}
+
+// MessageKey sets the key for the actual log message. By default, it's "msg".
+func MessageKey(key string) StdlibAdapterOption {
+	return func(a *StdlibAdapter) { a.messageKey = key }
+}
+
+// NewStdlibAdapter returns a new StdlibAdapter wrapper around the passed
+// logger. It's designed to be passed to log.SetOutput.
+func NewStdlibAdapter(logger Logger, options ...StdlibAdapterOption) io.Writer {
+	a := StdlibAdapter{
+		Logger:       logger,
+		timestampKey: "ts",
+		fileKey:      "file",
+		messageKey:   "msg",
+	}
+	for _, option := range options {
+		option(&a)
+	}
+	return a
+}
+
+func (a StdlibAdapter) Write(p []byte) (int, error) {
+	result := subexps(p)
+	keyvals := []interface{}{}
+	var timestamp string
+	if date, ok := result["date"]; ok && date != "" {
+		timestamp = date
+	}
+	if time, ok := result["time"]; ok && time != "" {
+		if timestamp != "" {
+			timestamp += " "
+		}
+		timestamp += time
+	}
+	if timestamp != "" {
+		keyvals = append(keyvals, a.timestampKey, timestamp)
+	}
+	if file, ok := result["file"]; ok && file != "" {
+		keyvals = append(keyvals, a.fileKey, file)
+	}
+	if msg, ok := result["msg"]; ok {
+		keyvals = append(keyvals, a.messageKey, msg)
+	}
+	if err := a.Logger.Log(keyvals...); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+const (
+	logRegexpDate = `(?P<date>[0-9]{4}/[0-9]{2}/[0-9]{2})?[ ]?`
+	logRegexpTime = `(?P<time>[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?)?[ ]?`
+	logRegexpFile = `(?P<file>.+?:[0-9]+)?`
+	logRegexpMsg  = `(: )?(?P<msg>.*)`
+)
+
+var (
+	logRegexp = regexp.MustCompile(logRegexpDate + logRegexpTime + logRegexpFile + logRegexpMsg)
+)
+
+func subexps(line []byte) map[string]string {
+	m := logRegexp.FindSubmatch(line)
+	if len(m) < len(logRegexp.SubexpNames()) {
+		return map[string]string{}
+	}
+	result := map[string]string{}
+	for i, name := range logRegexp.SubexpNames() {
+		result[name] = string(m[i])
+	}
+	return result
+}

--- a/vendor/github.com/go-kit/kit/log/sync.go
+++ b/vendor/github.com/go-kit/kit/log/sync.go
@@ -1,0 +1,81 @@
+package log
+
+import (
+	"io"
+	"sync"
+	"sync/atomic"
+)
+
+// SwapLogger wraps another logger that may be safely replaced while other
+// goroutines use the SwapLogger concurrently. The zero value for a SwapLogger
+// will discard all log events without error.
+//
+// SwapLogger serves well as a package global logger that can be changed by
+// importers.
+type SwapLogger struct {
+	logger atomic.Value
+}
+
+type loggerStruct struct {
+	Logger
+}
+
+// Log implements the Logger interface by forwarding keyvals to the currently
+// wrapped logger. It does not log anything if the wrapped logger is nil.
+func (l *SwapLogger) Log(keyvals ...interface{}) error {
+	s, ok := l.logger.Load().(loggerStruct)
+	if !ok || s.Logger == nil {
+		return nil
+	}
+	return s.Log(keyvals...)
+}
+
+// Swap replaces the currently wrapped logger with logger. Swap may be called
+// concurrently with calls to Log from other goroutines.
+func (l *SwapLogger) Swap(logger Logger) {
+	l.logger.Store(loggerStruct{logger})
+}
+
+// SyncWriter synchronizes concurrent writes to an io.Writer.
+type SyncWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// NewSyncWriter returns a new SyncWriter. The returned writer is safe for
+// concurrent use by multiple goroutines.
+func NewSyncWriter(w io.Writer) *SyncWriter {
+	return &SyncWriter{w: w}
+}
+
+// Write writes p to the underlying io.Writer. If another write is already in
+// progress, the calling goroutine blocks until the SyncWriter is available.
+func (w *SyncWriter) Write(p []byte) (n int, err error) {
+	w.mu.Lock()
+	n, err = w.w.Write(p)
+	w.mu.Unlock()
+	return n, err
+}
+
+// syncLogger provides concurrent safe logging for another Logger.
+type syncLogger struct {
+	mu     sync.Mutex
+	logger Logger
+}
+
+// NewSyncLogger returns a logger that synchronizes concurrent use of the
+// wrapped logger. When multiple goroutines use the SyncLogger concurrently
+// only one goroutine will be allowed to log to the wrapped logger at a time.
+// The other goroutines will block until the logger is available.
+func NewSyncLogger(logger Logger) Logger {
+	return &syncLogger{logger: logger}
+}
+
+// Log logs keyvals to the underlying Logger. If another log is already in
+// progress, the calling goroutine blocks until the syncLogger is available.
+func (l *syncLogger) Log(keyvals ...interface{}) error {
+	l.mu.Lock()
+	err := l.logger.Log(keyvals...)
+	l.mu.Unlock()
+	return err
+}

--- a/vendor/github.com/go-kit/kit/log/value.go
+++ b/vendor/github.com/go-kit/kit/log/value.go
@@ -1,0 +1,62 @@
+package log
+
+import (
+	"time"
+
+	"github.com/go-stack/stack"
+)
+
+// A Valuer generates a log value. When passed to Context.With in a value
+// element (odd indexes), it represents a dynamic value which is re-evaluated
+// with each log event.
+type Valuer func() interface{}
+
+// bindValues replaces all value elements (odd indexes) containing a Valuer
+// with their generated value.
+func bindValues(keyvals []interface{}) {
+	for i := 1; i < len(keyvals); i += 2 {
+		if v, ok := keyvals[i].(Valuer); ok {
+			keyvals[i] = v()
+		}
+	}
+}
+
+// containsValuer returns true if any of the value elements (odd indexes)
+// contain a Valuer.
+func containsValuer(keyvals []interface{}) bool {
+	for i := 1; i < len(keyvals); i += 2 {
+		if _, ok := keyvals[i].(Valuer); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Timestamp returns a Valuer that invokes the underlying function when bound,
+// returning a time.Time. Users will probably want to use DefaultTimestamp or
+// DefaultTimestampUTC.
+func Timestamp(t func() time.Time) Valuer {
+	return func() interface{} { return t() }
+}
+
+var (
+	// DefaultTimestamp is a Valuer that returns the current wallclock time,
+	// respecting time zones, when bound.
+	DefaultTimestamp Valuer = func() interface{} { return time.Now().Format(time.RFC3339) }
+
+	// DefaultTimestampUTC is a Valuer that returns the current time in UTC
+	// when bound.
+	DefaultTimestampUTC Valuer = func() interface{} { return time.Now().UTC().Format(time.RFC3339) }
+)
+
+// Caller returns a Valuer that returns a file and line from a specified depth
+// in the callstack. Users will probably want to use DefaultCaller.
+func Caller(depth int) Valuer {
+	return func() interface{} { return stack.Caller(depth) }
+}
+
+var (
+	// DefaultCaller is a Valuer that returns the file and line where the Log
+	// method was invoked. It can only be used with log.With.
+	DefaultCaller = Caller(3)
+)

--- a/vendor/github.com/go-logfmt/logfmt/.gitignore
+++ b/vendor/github.com/go-logfmt/logfmt/.gitignore
@@ -1,0 +1,4 @@
+_testdata/
+_testdata2/
+logfmt-fuzz.zip
+logfmt.test.exe

--- a/vendor/github.com/go-logfmt/logfmt/.travis.yml
+++ b/vendor/github.com/go-logfmt/logfmt/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+sudo: false
+go:
+  - 1.3
+  - 1.4
+  - 1.5
+  - 1.6
+  - tip
+
+before_install:
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+
+script:
+  - goveralls -service=travis-ci

--- a/vendor/github.com/go-logfmt/logfmt/LICENSE
+++ b/vendor/github.com/go-logfmt/logfmt/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 go-logfmt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/go-logfmt/logfmt/README.md
+++ b/vendor/github.com/go-logfmt/logfmt/README.md
@@ -1,0 +1,33 @@
+[![GoDoc](https://godoc.org/github.com/go-logfmt/logfmt?status.svg)](https://godoc.org/github.com/go-logfmt/logfmt)
+[![Go Report Card](https://goreportcard.com/badge/go-logfmt/logfmt)](https://goreportcard.com/report/go-logfmt/logfmt)
+[![TravisCI](https://travis-ci.org/go-logfmt/logfmt.svg?branch=master)](https://travis-ci.org/go-logfmt/logfmt)
+[![Coverage Status](https://coveralls.io/repos/github/go-logfmt/logfmt/badge.svg?branch=master)](https://coveralls.io/github/go-logfmt/logfmt?branch=master)
+
+# logfmt
+
+Package logfmt implements utilities to marshal and unmarshal data in the [logfmt
+format](https://brandur.org/logfmt). It provides an API similar to
+[encoding/json](http://golang.org/pkg/encoding/json/) and
+[encoding/xml](http://golang.org/pkg/encoding/xml/).
+
+The logfmt format was first documented by Brandur Leach in [this
+article](https://brandur.org/logfmt). The format has not been formally
+standardized. The most authoritative public specification to date has been the
+documentation of a Go Language [package](http://godoc.org/github.com/kr/logfmt)
+written by Blake Mizerany and Keith Rarick.
+
+## Goals
+
+This project attempts to conform as closely as possible to the prior art, while
+also removing ambiguity where necessary to provide well behaved encoder and
+decoder implementations.
+
+## Non-goals
+
+This project does not attempt to formally standardize the logfmt format. In the
+event that logfmt is standardized this project would take conforming to the
+standard as a goal.
+
+## Versioning
+
+Package logfmt publishes releases via [semver](http://semver.org/) compatible Git tags prefixed with a single 'v'.

--- a/vendor/github.com/go-logfmt/logfmt/decode.go
+++ b/vendor/github.com/go-logfmt/logfmt/decode.go
@@ -1,0 +1,222 @@
+package logfmt
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+)
+
+// A Decoder reads and decodes logfmt records from an input stream.
+type Decoder struct {
+	pos     int
+	key     []byte
+	value   []byte
+	lineNum int
+	s       *bufio.Scanner
+	err     error
+}
+
+// NewDecoder returns a new decoder that reads from r.
+//
+// The decoder introduces its own buffering and may read data from r beyond
+// the logfmt records requested.
+func NewDecoder(r io.Reader) *Decoder {
+	dec := &Decoder{
+		s: bufio.NewScanner(r),
+	}
+	return dec
+}
+
+// ScanRecord advances the Decoder to the next record, which can then be
+// parsed with the ScanKeyval method. It returns false when decoding stops,
+// either by reaching the end of the input or an error. After ScanRecord
+// returns false, the Err method will return any error that occurred during
+// decoding, except that if it was io.EOF, Err will return nil.
+func (dec *Decoder) ScanRecord() bool {
+	if dec.err != nil {
+		return false
+	}
+	if !dec.s.Scan() {
+		dec.err = dec.s.Err()
+		return false
+	}
+	dec.lineNum++
+	dec.pos = 0
+	return true
+}
+
+// ScanKeyval advances the Decoder to the next key/value pair of the current
+// record, which can then be retrieved with the Key and Value methods. It
+// returns false when decoding stops, either by reaching the end of the
+// current record or an error.
+func (dec *Decoder) ScanKeyval() bool {
+	dec.key, dec.value = nil, nil
+	if dec.err != nil {
+		return false
+	}
+
+	line := dec.s.Bytes()
+
+	// garbage
+	for p, c := range line[dec.pos:] {
+		if c > ' ' {
+			dec.pos += p
+			goto key
+		}
+	}
+	dec.pos = len(line)
+	return false
+
+key:
+	start := dec.pos
+	for p, c := range line[dec.pos:] {
+		switch {
+		case c == '=':
+			dec.pos += p
+			if dec.pos > start {
+				dec.key = line[start:dec.pos]
+			}
+			if dec.key == nil {
+				dec.unexpectedByte(c)
+				return false
+			}
+			goto equal
+		case c == '"':
+			dec.pos += p
+			dec.unexpectedByte(c)
+			return false
+		case c <= ' ':
+			dec.pos += p
+			if dec.pos > start {
+				dec.key = line[start:dec.pos]
+			}
+			return true
+		}
+	}
+	dec.pos = len(line)
+	if dec.pos > start {
+		dec.key = line[start:dec.pos]
+	}
+	return true
+
+equal:
+	dec.pos++
+	if dec.pos >= len(line) {
+		return true
+	}
+	switch c := line[dec.pos]; {
+	case c <= ' ':
+		return true
+	case c == '"':
+		goto qvalue
+	}
+
+	// value
+	start = dec.pos
+	for p, c := range line[dec.pos:] {
+		switch {
+		case c == '=' || c == '"':
+			dec.pos += p
+			dec.unexpectedByte(c)
+			return false
+		case c <= ' ':
+			dec.pos += p
+			if dec.pos > start {
+				dec.value = line[start:dec.pos]
+			}
+			return true
+		}
+	}
+	dec.pos = len(line)
+	if dec.pos > start {
+		dec.value = line[start:dec.pos]
+	}
+	return true
+
+qvalue:
+	const (
+		untermQuote  = "unterminated quoted value"
+		invalidQuote = "invalid quoted value"
+	)
+
+	hasEsc, esc := false, false
+	start = dec.pos
+	for p, c := range line[dec.pos+1:] {
+		switch {
+		case esc:
+			esc = false
+		case c == '\\':
+			hasEsc, esc = true, true
+		case c == '"':
+			dec.pos += p + 2
+			if hasEsc {
+				v, ok := unquoteBytes(line[start:dec.pos])
+				if !ok {
+					dec.syntaxError(invalidQuote)
+					return false
+				}
+				dec.value = v
+			} else {
+				start++
+				end := dec.pos - 1
+				if end > start {
+					dec.value = line[start:end]
+				}
+			}
+			return true
+		}
+	}
+	dec.pos = len(line)
+	dec.syntaxError(untermQuote)
+	return false
+}
+
+// Key returns the most recent key found by a call to ScanKeyval. The returned
+// slice may point to internal buffers and is only valid until the next call
+// to ScanRecord.  It does no allocation.
+func (dec *Decoder) Key() []byte {
+	return dec.key
+}
+
+// Value returns the most recent value found by a call to ScanKeyval. The
+// returned slice may point to internal buffers and is only valid until the
+// next call to ScanRecord.  It does no allocation when the value has no
+// escape sequences.
+func (dec *Decoder) Value() []byte {
+	return dec.value
+}
+
+// func (dec *Decoder) DecodeValue() ([]byte, error) {
+// }
+
+// Err returns the first non-EOF error that was encountered by the Scanner.
+func (dec *Decoder) Err() error {
+	return dec.err
+}
+
+func (dec *Decoder) syntaxError(msg string) {
+	dec.err = &SyntaxError{
+		Msg:  msg,
+		Line: dec.lineNum,
+		Pos:  dec.pos + 1,
+	}
+}
+
+func (dec *Decoder) unexpectedByte(c byte) {
+	dec.err = &SyntaxError{
+		Msg:  fmt.Sprintf("unexpected %q", c),
+		Line: dec.lineNum,
+		Pos:  dec.pos + 1,
+	}
+}
+
+// A SyntaxError represents a syntax error in the logfmt input stream.
+type SyntaxError struct {
+	Msg  string
+	Line int
+	Pos  int
+}
+
+func (e *SyntaxError) Error() string {
+	return fmt.Sprintf("logfmt syntax error at pos %d on line %d: %s", e.Pos, e.Line, e.Msg)
+}

--- a/vendor/github.com/go-logfmt/logfmt/doc.go
+++ b/vendor/github.com/go-logfmt/logfmt/doc.go
@@ -1,0 +1,6 @@
+// Package logfmt implements utilities to marshal and unmarshal data in the
+// logfmt format. The logfmt format records key/value pairs in a way that
+// balances readability for humans and simplicity of computer parsing. It is
+// most commonly used as a more human friendly alternative to JSON for
+// structured logging.
+package logfmt

--- a/vendor/github.com/go-logfmt/logfmt/encode.go
+++ b/vendor/github.com/go-logfmt/logfmt/encode.go
@@ -1,0 +1,312 @@
+package logfmt
+
+import (
+	"bytes"
+	"encoding"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+)
+
+// MarshalKeyvals returns the logfmt encoding of keyvals, a variadic sequence
+// of alternating keys and values.
+func MarshalKeyvals(keyvals ...interface{}) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	if err := NewEncoder(buf).EncodeKeyvals(keyvals...); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// An Encoder writes logfmt data to an output stream.
+type Encoder struct {
+	w       io.Writer
+	scratch bytes.Buffer
+	needSep bool
+}
+
+// NewEncoder returns a new encoder that writes to w.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{
+		w: w,
+	}
+}
+
+var (
+	space   = []byte(" ")
+	equals  = []byte("=")
+	newline = []byte("\n")
+	null    = []byte("null")
+)
+
+// EncodeKeyval writes the logfmt encoding of key and value to the stream. A
+// single space is written before the second and subsequent keys in a record.
+// Nothing is written if a non-nil error is returned.
+func (enc *Encoder) EncodeKeyval(key, value interface{}) error {
+	enc.scratch.Reset()
+	if enc.needSep {
+		if _, err := enc.scratch.Write(space); err != nil {
+			return err
+		}
+	}
+	if err := writeKey(&enc.scratch, key); err != nil {
+		return err
+	}
+	if _, err := enc.scratch.Write(equals); err != nil {
+		return err
+	}
+	if err := writeValue(&enc.scratch, value); err != nil {
+		return err
+	}
+	_, err := enc.w.Write(enc.scratch.Bytes())
+	enc.needSep = true
+	return err
+}
+
+// EncodeKeyvals writes the logfmt encoding of keyvals to the stream. Keyvals
+// is a variadic sequence of alternating keys and values. Keys of unsupported
+// type are skipped along with their corresponding value. Values of
+// unsupported type or that cause a MarshalerError are replaced by their error
+// but do not cause EncodeKeyvals to return an error. If a non-nil error is
+// returned some key/value pairs may not have be written.
+func (enc *Encoder) EncodeKeyvals(keyvals ...interface{}) error {
+	if len(keyvals) == 0 {
+		return nil
+	}
+	if len(keyvals)%2 == 1 {
+		keyvals = append(keyvals, nil)
+	}
+	for i := 0; i < len(keyvals); i += 2 {
+		k, v := keyvals[i], keyvals[i+1]
+		err := enc.EncodeKeyval(k, v)
+		if err == ErrUnsupportedKeyType {
+			continue
+		}
+		if _, ok := err.(*MarshalerError); ok || err == ErrUnsupportedValueType {
+			v = err
+			err = enc.EncodeKeyval(k, v)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MarshalerError represents an error encountered while marshaling a value.
+type MarshalerError struct {
+	Type reflect.Type
+	Err  error
+}
+
+func (e *MarshalerError) Error() string {
+	return "error marshaling value of type " + e.Type.String() + ": " + e.Err.Error()
+}
+
+// ErrNilKey is returned by Marshal functions and Encoder methods if a key is
+// a nil interface or pointer value.
+var ErrNilKey = errors.New("nil key")
+
+// ErrInvalidKey is returned by Marshal functions and Encoder methods if a key
+// contains an invalid character.
+var ErrInvalidKey = errors.New("invalid key")
+
+// ErrUnsupportedKeyType is returned by Encoder methods if a key has an
+// unsupported type.
+var ErrUnsupportedKeyType = errors.New("unsupported key type")
+
+// ErrUnsupportedValueType is returned by Encoder methods if a value has an
+// unsupported type.
+var ErrUnsupportedValueType = errors.New("unsupported value type")
+
+func writeKey(w io.Writer, key interface{}) error {
+	if key == nil {
+		return ErrNilKey
+	}
+
+	switch k := key.(type) {
+	case string:
+		return writeStringKey(w, k)
+	case []byte:
+		if k == nil {
+			return ErrNilKey
+		}
+		return writeBytesKey(w, k)
+	case encoding.TextMarshaler:
+		kb, err := safeMarshal(k)
+		if err != nil {
+			return err
+		}
+		if kb == nil {
+			return ErrNilKey
+		}
+		return writeBytesKey(w, kb)
+	case fmt.Stringer:
+		ks, ok := safeString(k)
+		if !ok {
+			return ErrNilKey
+		}
+		return writeStringKey(w, ks)
+	default:
+		rkey := reflect.ValueOf(key)
+		switch rkey.Kind() {
+		case reflect.Array, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice, reflect.Struct:
+			return ErrUnsupportedKeyType
+		case reflect.Ptr:
+			if rkey.IsNil() {
+				return ErrNilKey
+			}
+			return writeKey(w, rkey.Elem().Interface())
+		}
+		return writeStringKey(w, fmt.Sprint(k))
+	}
+}
+
+func invalidKeyRune(r rune) bool {
+	return r <= ' ' || r == '=' || r == '"'
+}
+
+func writeStringKey(w io.Writer, key string) error {
+	if len(key) == 0 || strings.IndexFunc(key, invalidKeyRune) != -1 {
+		return ErrInvalidKey
+	}
+	_, err := io.WriteString(w, key)
+	return err
+}
+
+func writeBytesKey(w io.Writer, key []byte) error {
+	if len(key) == 0 || bytes.IndexFunc(key, invalidKeyRune) != -1 {
+		return ErrInvalidKey
+	}
+	_, err := w.Write(key)
+	return err
+}
+
+func writeValue(w io.Writer, value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		return writeBytesValue(w, null)
+	case string:
+		return writeStringValue(w, v, true)
+	case []byte:
+		return writeBytesValue(w, v)
+	case encoding.TextMarshaler:
+		vb, err := safeMarshal(v)
+		if err != nil {
+			return err
+		}
+		if vb == nil {
+			vb = null
+		}
+		return writeBytesValue(w, vb)
+	case error:
+		se, ok := safeError(v)
+		return writeStringValue(w, se, ok)
+	case fmt.Stringer:
+		ss, ok := safeString(v)
+		return writeStringValue(w, ss, ok)
+	default:
+		rvalue := reflect.ValueOf(value)
+		switch rvalue.Kind() {
+		case reflect.Array, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice, reflect.Struct:
+			return ErrUnsupportedValueType
+		case reflect.Ptr:
+			if rvalue.IsNil() {
+				return writeBytesValue(w, null)
+			}
+			return writeValue(w, rvalue.Elem().Interface())
+		}
+		return writeStringValue(w, fmt.Sprint(v), true)
+	}
+}
+
+func needsQuotedValueRune(r rune) bool {
+	return r <= ' ' || r == '=' || r == '"'
+}
+
+func writeStringValue(w io.Writer, value string, ok bool) error {
+	var err error
+	if ok && value == "null" {
+		_, err = io.WriteString(w, `"null"`)
+	} else if strings.IndexFunc(value, needsQuotedValueRune) != -1 {
+		_, err = writeQuotedString(w, value)
+	} else {
+		_, err = io.WriteString(w, value)
+	}
+	return err
+}
+
+func writeBytesValue(w io.Writer, value []byte) error {
+	var err error
+	if bytes.IndexFunc(value, needsQuotedValueRune) >= 0 {
+		_, err = writeQuotedBytes(w, value)
+	} else {
+		_, err = w.Write(value)
+	}
+	return err
+}
+
+// EndRecord writes a newline character to the stream and resets the encoder
+// to the beginning of a new record.
+func (enc *Encoder) EndRecord() error {
+	_, err := enc.w.Write(newline)
+	if err == nil {
+		enc.needSep = false
+	}
+	return err
+}
+
+// Reset resets the encoder to the beginning of a new record.
+func (enc *Encoder) Reset() {
+	enc.needSep = false
+}
+
+func safeError(err error) (s string, ok bool) {
+	defer func() {
+		if panicVal := recover(); panicVal != nil {
+			if v := reflect.ValueOf(err); v.Kind() == reflect.Ptr && v.IsNil() {
+				s, ok = "null", false
+			} else {
+				panic(panicVal)
+			}
+		}
+	}()
+	s, ok = err.Error(), true
+	return
+}
+
+func safeString(str fmt.Stringer) (s string, ok bool) {
+	defer func() {
+		if panicVal := recover(); panicVal != nil {
+			if v := reflect.ValueOf(str); v.Kind() == reflect.Ptr && v.IsNil() {
+				s, ok = "null", false
+			} else {
+				panic(panicVal)
+			}
+		}
+	}()
+	s, ok = str.String(), true
+	return
+}
+
+func safeMarshal(tm encoding.TextMarshaler) (b []byte, err error) {
+	defer func() {
+		if panicVal := recover(); panicVal != nil {
+			if v := reflect.ValueOf(tm); v.Kind() == reflect.Ptr && v.IsNil() {
+				b, err = nil, nil
+			} else {
+				panic(panicVal)
+			}
+		}
+	}()
+	b, err = tm.MarshalText()
+	if err != nil {
+		return nil, &MarshalerError{
+			Type: reflect.TypeOf(tm),
+			Err:  err,
+		}
+	}
+	return
+}

--- a/vendor/github.com/go-logfmt/logfmt/fuzz.go
+++ b/vendor/github.com/go-logfmt/logfmt/fuzz.go
@@ -1,0 +1,125 @@
+// +build gofuzz
+
+package logfmt
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+
+	kr "github.com/kr/logfmt"
+)
+
+func Fuzz(data []byte) int {
+	parsed, err := parse(data)
+	if err != nil {
+		return 0
+	}
+	var w1 bytes.Buffer
+	if err := write(parsed, &w1); err != nil {
+		panic(err)
+	}
+	parsed, err = parse(data)
+	if err != nil {
+		panic(err)
+	}
+	var w2 bytes.Buffer
+	if err := write(parsed, &w2); err != nil {
+		panic(err)
+	}
+	if !bytes.Equal(w1.Bytes(), w2.Bytes()) {
+		panic(fmt.Sprintf("reserialized data does not match:\n%q\n%q\n", w1.Bytes(), w2.Bytes()))
+	}
+	return 1
+}
+
+func FuzzVsKR(data []byte) int {
+	parsed, err := parse(data)
+	parsedKR, errKR := parseKR(data)
+
+	// github.com/go-logfmt/logfmt is a stricter parser. It returns errors for
+	// more inputs than github.com/kr/logfmt. Ignore any inputs that have a
+	// stict error.
+	if err != nil {
+		return 0
+	}
+
+	// Fail if the more forgiving parser finds an error not found by the
+	// stricter parser.
+	if errKR != nil {
+		panic(fmt.Sprintf("unmatched error: %v", errKR))
+	}
+
+	if !reflect.DeepEqual(parsed, parsedKR) {
+		panic(fmt.Sprintf("parsers disagree:\n%+v\n%+v\n", parsed, parsedKR))
+	}
+	return 1
+}
+
+type kv struct {
+	k, v []byte
+}
+
+func parse(data []byte) ([][]kv, error) {
+	var got [][]kv
+	dec := NewDecoder(bytes.NewReader(data))
+	for dec.ScanRecord() {
+		var kvs []kv
+		for dec.ScanKeyval() {
+			kvs = append(kvs, kv{dec.Key(), dec.Value()})
+		}
+		got = append(got, kvs)
+		kvs = nil
+	}
+	return got, dec.Err()
+}
+
+func parseKR(data []byte) ([][]kv, error) {
+	var (
+		s   = bufio.NewScanner(bytes.NewReader(data))
+		err error
+		h   saveHandler
+		got [][]kv
+	)
+	for err == nil && s.Scan() {
+		h.kvs = nil
+		err = kr.Unmarshal(s.Bytes(), &h)
+		got = append(got, h.kvs)
+	}
+	if err == nil {
+		err = s.Err()
+	}
+	return got, err
+}
+
+type saveHandler struct {
+	kvs []kv
+}
+
+func (h *saveHandler) HandleLogfmt(key, val []byte) error {
+	if len(key) == 0 {
+		key = nil
+	}
+	if len(val) == 0 {
+		val = nil
+	}
+	h.kvs = append(h.kvs, kv{key, val})
+	return nil
+}
+
+func write(recs [][]kv, w io.Writer) error {
+	enc := NewEncoder(w)
+	for _, rec := range recs {
+		for _, f := range rec {
+			if err := enc.EncodeKeyval(f.k, f.v); err != nil {
+				return err
+			}
+		}
+		if err := enc.EndRecord(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/go-logfmt/logfmt/jsonstring.go
+++ b/vendor/github.com/go-logfmt/logfmt/jsonstring.go
@@ -1,0 +1,277 @@
+package logfmt
+
+import (
+	"bytes"
+	"io"
+	"strconv"
+	"sync"
+	"unicode"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// Taken from Go's encoding/json and modified for use here.
+
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+var hex = "0123456789abcdef"
+
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		return &bytes.Buffer{}
+	},
+}
+
+func getBuffer() *bytes.Buffer {
+	return bufferPool.Get().(*bytes.Buffer)
+}
+
+func poolBuffer(buf *bytes.Buffer) {
+	buf.Reset()
+	bufferPool.Put(buf)
+}
+
+// NOTE: keep in sync with writeQuotedBytes below.
+func writeQuotedString(w io.Writer, s string) (int, error) {
+	buf := getBuffer()
+	buf.WriteByte('"')
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if 0x20 <= b && b != '\\' && b != '"' {
+				i++
+				continue
+			}
+			if start < i {
+				buf.WriteString(s[start:i])
+			}
+			switch b {
+			case '\\', '"':
+				buf.WriteByte('\\')
+				buf.WriteByte(b)
+			case '\n':
+				buf.WriteByte('\\')
+				buf.WriteByte('n')
+			case '\r':
+				buf.WriteByte('\\')
+				buf.WriteByte('r')
+			case '\t':
+				buf.WriteByte('\\')
+				buf.WriteByte('t')
+			default:
+				// This encodes bytes < 0x20 except for \n, \r, and \t.
+				buf.WriteString(`\u00`)
+				buf.WriteByte(hex[b>>4])
+				buf.WriteByte(hex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRuneInString(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				buf.WriteString(s[start:i])
+			}
+			buf.WriteString(`\ufffd`)
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(s) {
+		buf.WriteString(s[start:])
+	}
+	buf.WriteByte('"')
+	n, err := w.Write(buf.Bytes())
+	poolBuffer(buf)
+	return n, err
+}
+
+// NOTE: keep in sync with writeQuoteString above.
+func writeQuotedBytes(w io.Writer, s []byte) (int, error) {
+	buf := getBuffer()
+	buf.WriteByte('"')
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if 0x20 <= b && b != '\\' && b != '"' {
+				i++
+				continue
+			}
+			if start < i {
+				buf.Write(s[start:i])
+			}
+			switch b {
+			case '\\', '"':
+				buf.WriteByte('\\')
+				buf.WriteByte(b)
+			case '\n':
+				buf.WriteByte('\\')
+				buf.WriteByte('n')
+			case '\r':
+				buf.WriteByte('\\')
+				buf.WriteByte('r')
+			case '\t':
+				buf.WriteByte('\\')
+				buf.WriteByte('t')
+			default:
+				// This encodes bytes < 0x20 except for \n, \r, and \t.
+				buf.WriteString(`\u00`)
+				buf.WriteByte(hex[b>>4])
+				buf.WriteByte(hex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRune(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				buf.Write(s[start:i])
+			}
+			buf.WriteString(`\ufffd`)
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(s) {
+		buf.Write(s[start:])
+	}
+	buf.WriteByte('"')
+	n, err := w.Write(buf.Bytes())
+	poolBuffer(buf)
+	return n, err
+}
+
+// getu4 decodes \uXXXX from the beginning of s, returning the hex value,
+// or it returns -1.
+func getu4(s []byte) rune {
+	if len(s) < 6 || s[0] != '\\' || s[1] != 'u' {
+		return -1
+	}
+	r, err := strconv.ParseUint(string(s[2:6]), 16, 64)
+	if err != nil {
+		return -1
+	}
+	return rune(r)
+}
+
+func unquoteBytes(s []byte) (t []byte, ok bool) {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return
+	}
+	s = s[1 : len(s)-1]
+
+	// Check for unusual characters. If there are none,
+	// then no unquoting is needed, so return a slice of the
+	// original bytes.
+	r := 0
+	for r < len(s) {
+		c := s[r]
+		if c == '\\' || c == '"' || c < ' ' {
+			break
+		}
+		if c < utf8.RuneSelf {
+			r++
+			continue
+		}
+		rr, size := utf8.DecodeRune(s[r:])
+		if rr == utf8.RuneError && size == 1 {
+			break
+		}
+		r += size
+	}
+	if r == len(s) {
+		return s, true
+	}
+
+	b := make([]byte, len(s)+2*utf8.UTFMax)
+	w := copy(b, s[0:r])
+	for r < len(s) {
+		// Out of room?  Can only happen if s is full of
+		// malformed UTF-8 and we're replacing each
+		// byte with RuneError.
+		if w >= len(b)-2*utf8.UTFMax {
+			nb := make([]byte, (len(b)+utf8.UTFMax)*2)
+			copy(nb, b[0:w])
+			b = nb
+		}
+		switch c := s[r]; {
+		case c == '\\':
+			r++
+			if r >= len(s) {
+				return
+			}
+			switch s[r] {
+			default:
+				return
+			case '"', '\\', '/', '\'':
+				b[w] = s[r]
+				r++
+				w++
+			case 'b':
+				b[w] = '\b'
+				r++
+				w++
+			case 'f':
+				b[w] = '\f'
+				r++
+				w++
+			case 'n':
+				b[w] = '\n'
+				r++
+				w++
+			case 'r':
+				b[w] = '\r'
+				r++
+				w++
+			case 't':
+				b[w] = '\t'
+				r++
+				w++
+			case 'u':
+				r--
+				rr := getu4(s[r:])
+				if rr < 0 {
+					return
+				}
+				r += 6
+				if utf16.IsSurrogate(rr) {
+					rr1 := getu4(s[r:])
+					if dec := utf16.DecodeRune(rr, rr1); dec != unicode.ReplacementChar {
+						// A valid pair; consume.
+						r += 6
+						w += utf8.EncodeRune(b[w:], dec)
+						break
+					}
+					// Invalid surrogate; fall back to replacement rune.
+					rr = unicode.ReplacementChar
+				}
+				w += utf8.EncodeRune(b[w:], rr)
+			}
+
+		// Quote, control characters are invalid.
+		case c == '"', c < ' ':
+			return
+
+		// ASCII
+		case c < utf8.RuneSelf:
+			b[w] = c
+			r++
+			w++
+
+		// Coerce to well-formed UTF-8.
+		default:
+			rr, size := utf8.DecodeRune(s[r:])
+			r += size
+			w += utf8.EncodeRune(b[w:], rr)
+		}
+	}
+	return b[0:w], true
+}

--- a/vendor/github.com/go-stack/stack/.travis.yml
+++ b/vendor/github.com/go-stack/stack/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+sudo: false
+go:
+  - 1.2
+  - 1.3
+  - 1.4
+  - 1.5
+  - 1.6
+  - tip
+
+before_install:
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+
+script:
+  - goveralls -service=travis-ci

--- a/vendor/github.com/go-stack/stack/LICENSE.md
+++ b/vendor/github.com/go-stack/stack/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright 2014 Chris Hines
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/go-stack/stack/README.md
+++ b/vendor/github.com/go-stack/stack/README.md
@@ -1,0 +1,38 @@
+[![GoDoc](https://godoc.org/github.com/go-stack/stack?status.svg)](https://godoc.org/github.com/go-stack/stack)
+[![Go Report Card](https://goreportcard.com/badge/go-stack/stack)](https://goreportcard.com/report/go-stack/stack)
+[![TravisCI](https://travis-ci.org/go-stack/stack.svg?branch=master)](https://travis-ci.org/go-stack/stack)
+[![Coverage Status](https://coveralls.io/repos/github/go-stack/stack/badge.svg?branch=master)](https://coveralls.io/github/go-stack/stack?branch=master)
+
+# stack
+
+Package stack implements utilities to capture, manipulate, and format call
+stacks. It provides a simpler API than package runtime.
+
+The implementation takes care of the minutia and special cases of interpreting
+the program counter (pc) values returned by runtime.Callers.
+
+## Versioning
+
+Package stack publishes releases via [semver](http://semver.org/) compatible Git
+tags prefixed with a single 'v'. The master branch always contains the latest
+release. The develop branch contains unreleased commits.
+
+## Formatting
+
+Package stack's types implement fmt.Formatter, which provides a simple and
+flexible way to declaratively configure formatting when used with logging or
+error tracking packages.
+
+```go
+func DoTheThing() {
+    c := stack.Caller(0)
+    log.Print(c)          // "source.go:10"
+    log.Printf("%+v", c)  // "pkg/path/source.go:10"
+    log.Printf("%n", c)   // "DoTheThing"
+
+    s := stack.Trace().TrimRuntime()
+    log.Print(s)          // "[source.go:15 caller.go:42 main.go:14]"
+}
+```
+
+See the docs for all of the supported formatting options.

--- a/vendor/github.com/go-stack/stack/stack.go
+++ b/vendor/github.com/go-stack/stack/stack.go
@@ -1,0 +1,349 @@
+// Package stack implements utilities to capture, manipulate, and format call
+// stacks. It provides a simpler API than package runtime.
+//
+// The implementation takes care of the minutia and special cases of
+// interpreting the program counter (pc) values returned by runtime.Callers.
+//
+// Package stack's types implement fmt.Formatter, which provides a simple and
+// flexible way to declaratively configure formatting when used with logging
+// or error tracking packages.
+package stack
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// Call records a single function invocation from a goroutine stack.
+type Call struct {
+	fn *runtime.Func
+	pc uintptr
+}
+
+// Caller returns a Call from the stack of the current goroutine. The argument
+// skip is the number of stack frames to ascend, with 0 identifying the
+// calling function.
+func Caller(skip int) Call {
+	var pcs [2]uintptr
+	n := runtime.Callers(skip+1, pcs[:])
+
+	var c Call
+
+	if n < 2 {
+		return c
+	}
+
+	c.pc = pcs[1]
+	if runtime.FuncForPC(pcs[0]) != sigpanic {
+		c.pc--
+	}
+	c.fn = runtime.FuncForPC(c.pc)
+	return c
+}
+
+// String implements fmt.Stinger. It is equivalent to fmt.Sprintf("%v", c).
+func (c Call) String() string {
+	return fmt.Sprint(c)
+}
+
+// MarshalText implements encoding.TextMarshaler. It formats the Call the same
+// as fmt.Sprintf("%v", c).
+func (c Call) MarshalText() ([]byte, error) {
+	if c.fn == nil {
+		return nil, ErrNoFunc
+	}
+	buf := bytes.Buffer{}
+	fmt.Fprint(&buf, c)
+	return buf.Bytes(), nil
+}
+
+// ErrNoFunc means that the Call has a nil *runtime.Func. The most likely
+// cause is a Call with the zero value.
+var ErrNoFunc = errors.New("no call stack information")
+
+// Format implements fmt.Formatter with support for the following verbs.
+//
+//    %s    source file
+//    %d    line number
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// It accepts the '+' and '#' flags for most of the verbs as follows.
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %#s   full path of source file
+//    %+n   import path qualified function name
+//    %+v   equivalent to %+s:%d
+//    %#v   equivalent to %#s:%d
+func (c Call) Format(s fmt.State, verb rune) {
+	if c.fn == nil {
+		fmt.Fprintf(s, "%%!%c(NOFUNC)", verb)
+		return
+	}
+
+	switch verb {
+	case 's', 'v':
+		file, line := c.fn.FileLine(c.pc)
+		switch {
+		case s.Flag('#'):
+			// done
+		case s.Flag('+'):
+			file = file[pkgIndex(file, c.fn.Name()):]
+		default:
+			const sep = "/"
+			if i := strings.LastIndex(file, sep); i != -1 {
+				file = file[i+len(sep):]
+			}
+		}
+		io.WriteString(s, file)
+		if verb == 'v' {
+			buf := [7]byte{':'}
+			s.Write(strconv.AppendInt(buf[:1], int64(line), 10))
+		}
+
+	case 'd':
+		_, line := c.fn.FileLine(c.pc)
+		buf := [6]byte{}
+		s.Write(strconv.AppendInt(buf[:0], int64(line), 10))
+
+	case 'n':
+		name := c.fn.Name()
+		if !s.Flag('+') {
+			const pathSep = "/"
+			if i := strings.LastIndex(name, pathSep); i != -1 {
+				name = name[i+len(pathSep):]
+			}
+			const pkgSep = "."
+			if i := strings.Index(name, pkgSep); i != -1 {
+				name = name[i+len(pkgSep):]
+			}
+		}
+		io.WriteString(s, name)
+	}
+}
+
+// PC returns the program counter for this call frame; multiple frames may
+// have the same PC value.
+func (c Call) PC() uintptr {
+	return c.pc
+}
+
+// name returns the import path qualified name of the function containing the
+// call.
+func (c Call) name() string {
+	if c.fn == nil {
+		return "???"
+	}
+	return c.fn.Name()
+}
+
+func (c Call) file() string {
+	if c.fn == nil {
+		return "???"
+	}
+	file, _ := c.fn.FileLine(c.pc)
+	return file
+}
+
+func (c Call) line() int {
+	if c.fn == nil {
+		return 0
+	}
+	_, line := c.fn.FileLine(c.pc)
+	return line
+}
+
+// CallStack records a sequence of function invocations from a goroutine
+// stack.
+type CallStack []Call
+
+// String implements fmt.Stinger. It is equivalent to fmt.Sprintf("%v", cs).
+func (cs CallStack) String() string {
+	return fmt.Sprint(cs)
+}
+
+var (
+	openBracketBytes  = []byte("[")
+	closeBracketBytes = []byte("]")
+	spaceBytes        = []byte(" ")
+)
+
+// MarshalText implements encoding.TextMarshaler. It formats the CallStack the
+// same as fmt.Sprintf("%v", cs).
+func (cs CallStack) MarshalText() ([]byte, error) {
+	buf := bytes.Buffer{}
+	buf.Write(openBracketBytes)
+	for i, pc := range cs {
+		if pc.fn == nil {
+			return nil, ErrNoFunc
+		}
+		if i > 0 {
+			buf.Write(spaceBytes)
+		}
+		fmt.Fprint(&buf, pc)
+	}
+	buf.Write(closeBracketBytes)
+	return buf.Bytes(), nil
+}
+
+// Format implements fmt.Formatter by printing the CallStack as square brackets
+// ([, ]) surrounding a space separated list of Calls each formatted with the
+// supplied verb and options.
+func (cs CallStack) Format(s fmt.State, verb rune) {
+	s.Write(openBracketBytes)
+	for i, pc := range cs {
+		if i > 0 {
+			s.Write(spaceBytes)
+		}
+		pc.Format(s, verb)
+	}
+	s.Write(closeBracketBytes)
+}
+
+// findSigpanic intentionally executes faulting code to generate a stack trace
+// containing an entry for runtime.sigpanic.
+func findSigpanic() *runtime.Func {
+	var fn *runtime.Func
+	var p *int
+	func() int {
+		defer func() {
+			if p := recover(); p != nil {
+				var pcs [512]uintptr
+				n := runtime.Callers(2, pcs[:])
+				for _, pc := range pcs[:n] {
+					f := runtime.FuncForPC(pc)
+					if f.Name() == "runtime.sigpanic" {
+						fn = f
+						break
+					}
+				}
+			}
+		}()
+		// intentional nil pointer dereference to trigger sigpanic
+		return *p
+	}()
+	return fn
+}
+
+var sigpanic = findSigpanic()
+
+// Trace returns a CallStack for the current goroutine with element 0
+// identifying the calling function.
+func Trace() CallStack {
+	var pcs [512]uintptr
+	n := runtime.Callers(2, pcs[:])
+	cs := make([]Call, n)
+
+	for i, pc := range pcs[:n] {
+		pcFix := pc
+		if i > 0 && cs[i-1].fn != sigpanic {
+			pcFix--
+		}
+		cs[i] = Call{
+			fn: runtime.FuncForPC(pcFix),
+			pc: pcFix,
+		}
+	}
+
+	return cs
+}
+
+// TrimBelow returns a slice of the CallStack with all entries below c
+// removed.
+func (cs CallStack) TrimBelow(c Call) CallStack {
+	for len(cs) > 0 && cs[0].pc != c.pc {
+		cs = cs[1:]
+	}
+	return cs
+}
+
+// TrimAbove returns a slice of the CallStack with all entries above c
+// removed.
+func (cs CallStack) TrimAbove(c Call) CallStack {
+	for len(cs) > 0 && cs[len(cs)-1].pc != c.pc {
+		cs = cs[:len(cs)-1]
+	}
+	return cs
+}
+
+// pkgIndex returns the index that results in file[index:] being the path of
+// file relative to the compile time GOPATH, and file[:index] being the
+// $GOPATH/src/ portion of file. funcName must be the name of a function in
+// file as returned by runtime.Func.Name.
+func pkgIndex(file, funcName string) int {
+	// As of Go 1.6.2 there is no direct way to know the compile time GOPATH
+	// at runtime, but we can infer the number of path segments in the GOPATH.
+	// We note that runtime.Func.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    file[:idx] == /home/user/src/
+	//    file[idx:] == pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired result for file[idx:]. We count separators from the
+	// end of the file path until it finds two more than in the function name
+	// and then move one character forward to preserve the initial path
+	// segment without a leading separator.
+	const sep = "/"
+	i := len(file)
+	for n := strings.Count(funcName, sep) + 2; n > 0; n-- {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	return i + len(sep)
+}
+
+var runtimePath string
+
+func init() {
+	var pcs [1]uintptr
+	runtime.Callers(0, pcs[:])
+	fn := runtime.FuncForPC(pcs[0])
+	file, _ := fn.FileLine(pcs[0])
+
+	idx := pkgIndex(file, fn.Name())
+
+	runtimePath = file[:idx]
+	if runtime.GOOS == "windows" {
+		runtimePath = strings.ToLower(runtimePath)
+	}
+}
+
+func inGoroot(c Call) bool {
+	file := c.file()
+	if len(file) == 0 || file[0] == '?' {
+		return true
+	}
+	if runtime.GOOS == "windows" {
+		file = strings.ToLower(file)
+	}
+	return strings.HasPrefix(file, runtimePath) || strings.HasSuffix(file, "/_testmain.go")
+}
+
+// TrimRuntime returns a slice of the CallStack with the topmost entries from
+// the go runtime removed. It considers any calls originating from unknown
+// files, files under GOROOT, or _testmain.go as part of the runtime.
+func (cs CallStack) TrimRuntime() CallStack {
+	for len(cs) > 0 && inGoroot(cs[len(cs)-1]) {
+		cs = cs[:len(cs)-1]
+	}
+	return cs
+}

--- a/vendor/github.com/kr/logfmt/.gitignore
+++ b/vendor/github.com/kr/logfmt/.gitignore
@@ -1,0 +1,3 @@
+*.test
+*.swp
+*.prof

--- a/vendor/github.com/kr/logfmt/Readme
+++ b/vendor/github.com/kr/logfmt/Readme
@@ -1,0 +1,12 @@
+Go package for parsing (and, eventually, generating)
+log lines in the logfmt style.
+
+See http://godoc.org/github.com/kr/logfmt for format, and other documentation and examples.
+
+Copyright (C) 2013 Keith Rarick, Blake Mizerany
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/kr/logfmt/decode.go
+++ b/vendor/github.com/kr/logfmt/decode.go
@@ -1,0 +1,184 @@
+// Package implements the decoding of logfmt key-value pairs.
+//
+// Example logfmt message:
+//
+//	foo=bar a=14 baz="hello kitty" cool%story=bro f %^asdf
+//
+// Example result in JSON:
+//
+//	{ "foo": "bar", "a": 14, "baz": "hello kitty", "cool%story": "bro", "f": true, "%^asdf": true }
+//
+// EBNFish:
+//
+// 	ident_byte = any byte greater than ' ', excluding '=' and '"'
+// 	string_byte = any byte excluding '"' and '\'
+// 	garbage = !ident_byte
+// 	ident = ident_byte, { ident byte }
+// 	key = ident
+// 	value = ident | '"', { string_byte | '\', '"' }, '"'
+// 	pair = key, '=', value | key, '=' | key
+// 	message = { garbage, pair }, garbage
+package logfmt
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Handler is the interface implemented by objects that accept logfmt
+// key-value pairs. HandleLogfmt must copy the logfmt data if it
+// wishes to retain the data after returning.
+type Handler interface {
+	HandleLogfmt(key, val []byte) error
+}
+
+// The HandlerFunc type is an adapter to allow the use of ordinary functions as
+// logfmt handlers. If f is a function with the appropriate signature,
+// HandlerFunc(f) is a Handler object that calls f.
+type HandlerFunc func(key, val []byte) error
+
+func (f HandlerFunc) HandleLogfmt(key, val []byte) error {
+	return f(key, val)
+}
+
+// Unmarshal parses the logfmt encoding data and stores the result in the value
+// pointed to by v. If v is an Handler, HandleLogfmt will be called for each
+// key-value pair.
+//
+// If v is not a Handler, it will pass v to NewStructHandler and use the
+// returned StructHandler for decoding.
+func Unmarshal(data []byte, v interface{}) (err error) {
+	h, ok := v.(Handler)
+	if !ok {
+		h, err = NewStructHandler(v)
+		if err != nil {
+			return err
+		}
+	}
+	return gotoScanner(data, h)
+}
+
+// StructHandler unmarshals logfmt into a struct. It matches incoming keys to
+// the the struct's fields (either the struct field name or its tag, preferring
+// an exact match but also accepting a case-insensitive match.
+//
+// Field types supported by StructHandler are:
+//
+// 	all numeric types (e.g. float32, int, etc.)
+// 	[]byte
+// 	string
+// 	bool - true if key is present, false otherwise (the value is ignored).
+//	time.Duration - uses time.ParseDuration
+//
+// If a field is a pointer to an above type, and a matching key is not present
+// in the logfmt data, the pointer will be untouched.
+//
+// If v is not a pointer to an Handler or struct, Unmarshal will return an
+// error.
+type StructHandler struct {
+	rv reflect.Value
+}
+
+func NewStructHandler(v interface{}) (Handler, error) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return nil, &InvalidUnmarshalError{reflect.TypeOf(v)}
+	}
+	return &StructHandler{rv: rv}, nil
+}
+
+func (h *StructHandler) HandleLogfmt(key, val []byte) error {
+	el := h.rv.Elem()
+	skey := string(key)
+	for i := 0; i < el.NumField(); i++ {
+		fv := el.Field(i)
+		ft := el.Type().Field(i)
+		switch {
+		case ft.Name == skey:
+		case ft.Tag.Get("logfmt") == skey:
+		case strings.EqualFold(ft.Name, skey):
+		default:
+			continue
+		}
+		if fv.Kind() == reflect.Ptr {
+			if fv.IsNil() {
+				t := fv.Type().Elem()
+				v := reflect.New(t)
+				fv.Set(v)
+				fv = v
+			}
+			fv = fv.Elem()
+		}
+		switch fv.Interface().(type) {
+		case time.Duration:
+			d, err := time.ParseDuration(string(val))
+			if err != nil {
+				return &UnmarshalTypeError{string(val), fv.Type()}
+			}
+			fv.Set(reflect.ValueOf(d))
+		case string:
+			fv.SetString(string(val))
+		case []byte:
+			b := make([]byte, len(val))
+			copy(b, val)
+			fv.SetBytes(b)
+		case bool:
+			fv.SetBool(true)
+		default:
+			switch {
+			case reflect.Int <= fv.Kind() && fv.Kind() <= reflect.Int64:
+				v, err := strconv.ParseInt(string(val), 10, 64)
+				if err != nil {
+					return err
+				}
+				fv.SetInt(v)
+			case reflect.Uint32 <= fv.Kind() && fv.Kind() <= reflect.Uint64:
+				v, err := strconv.ParseUint(string(val), 10, 64)
+				if err != nil {
+					return err
+				}
+				fv.SetUint(v)
+			case reflect.Float32 <= fv.Kind() && fv.Kind() <= reflect.Float64:
+				v, err := strconv.ParseFloat(string(val), 10)
+				if err != nil {
+					return err
+				}
+				fv.SetFloat(v)
+			default:
+				return &UnmarshalTypeError{string(val), fv.Type()}
+			}
+		}
+
+	}
+	return nil
+}
+
+// An InvalidUnmarshalError describes an invalid argument passed to Unmarshal.
+// (The argument to Unmarshal must be a non-nil pointer.)
+type InvalidUnmarshalError struct {
+	Type reflect.Type
+}
+
+func (e *InvalidUnmarshalError) Error() string {
+	if e.Type == nil {
+		return "logfmt: Unmarshal(nil)"
+	}
+
+	if e.Type.Kind() != reflect.Ptr {
+		return "logfmt: Unmarshal(non-pointer " + e.Type.String() + ")"
+	}
+	return "logfmt: Unmarshal(nil " + e.Type.String() + ")"
+}
+
+// An UnmarshalTypeError describes a logfmt value that was
+// not appropriate for a value of a specific Go type.
+type UnmarshalTypeError struct {
+	Value string       // the logfmt value
+	Type  reflect.Type // type of Go value it could not be assigned to
+}
+
+func (e *UnmarshalTypeError) Error() string {
+	return "logfmt: cannot unmarshal " + e.Value + " into Go value of type " + e.Type.String()
+}

--- a/vendor/github.com/kr/logfmt/scanner.go
+++ b/vendor/github.com/kr/logfmt/scanner.go
@@ -1,0 +1,149 @@
+package logfmt
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrUnterminatedString = errors.New("logfmt: unterminated string")
+
+func gotoScanner(data []byte, h Handler) (err error) {
+	saveError := func(e error) {
+		if err == nil {
+			err = e
+		}
+	}
+
+	var c byte
+	var i int
+	var m int
+	var key []byte
+	var val []byte
+	var ok bool
+	var esc bool
+
+garbage:
+	if i == len(data) {
+		return
+	}
+
+	c = data[i]
+	switch {
+	case c > ' ' && c != '"' && c != '=':
+		key, val = nil, nil
+		m = i
+		i++
+		goto key
+	default:
+		i++
+		goto garbage
+	}
+
+key:
+	if i >= len(data) {
+		if m >= 0 {
+			key = data[m:i]
+			saveError(h.HandleLogfmt(key, nil))
+		}
+		return
+	}
+
+	c = data[i]
+	switch {
+	case c > ' ' && c != '"' && c != '=':
+		i++
+		goto key
+	case c == '=':
+		key = data[m:i]
+		i++
+		goto equal
+	default:
+		key = data[m:i]
+		i++
+		saveError(h.HandleLogfmt(key, nil))
+		goto garbage
+	}
+
+equal:
+	if i >= len(data) {
+		if m >= 0 {
+			i--
+			key = data[m:i]
+			saveError(h.HandleLogfmt(key, nil))
+		}
+		return
+	}
+
+	c = data[i]
+	switch {
+	case c > ' ' && c != '"' && c != '=':
+		m = i
+		i++
+		goto ivalue
+	case c == '"':
+		m = i
+		i++
+		esc = false
+		goto qvalue
+	default:
+		if key != nil {
+			saveError(h.HandleLogfmt(key, val))
+		}
+		i++
+		goto garbage
+	}
+
+ivalue:
+	if i >= len(data) {
+		if m >= 0 {
+			val = data[m:i]
+			saveError(h.HandleLogfmt(key, val))
+		}
+		return
+	}
+
+	c = data[i]
+	switch {
+	case c > ' ' && c != '"' && c != '=':
+		i++
+		goto ivalue
+	default:
+		val = data[m:i]
+		saveError(h.HandleLogfmt(key, val))
+		i++
+		goto garbage
+	}
+
+qvalue:
+	if i >= len(data) {
+		if m >= 0 {
+			saveError(ErrUnterminatedString)
+		}
+		return
+	}
+
+	c = data[i]
+	switch c {
+	case '\\':
+		i += 2
+		esc = true
+		goto qvalue
+	case '"':
+		i++
+		val = data[m:i]
+		if esc {
+			val, ok = unquoteBytes(val)
+			if !ok {
+				saveError(fmt.Errorf("logfmt: error unquoting bytes %q", string(val)))
+				goto garbage
+			}
+		} else {
+			val = val[1 : len(val)-1]
+		}
+		saveError(h.HandleLogfmt(key, val))
+		goto garbage
+	default:
+		i++
+		goto qvalue
+	}
+}

--- a/vendor/github.com/kr/logfmt/unquote.go
+++ b/vendor/github.com/kr/logfmt/unquote.go
@@ -1,0 +1,149 @@
+package logfmt
+
+import (
+	"strconv"
+	"unicode"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// Taken from Go's encoding/json
+
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// getu4 decodes \uXXXX from the beginning of s, returning the hex value,
+// or it returns -1.
+func getu4(s []byte) rune {
+	if len(s) < 6 || s[0] != '\\' || s[1] != 'u' {
+		return -1
+	}
+	r, err := strconv.ParseUint(string(s[2:6]), 16, 64)
+	if err != nil {
+		return -1
+	}
+	return rune(r)
+}
+
+// unquote converts a quoted JSON string literal s into an actual string t.
+// The rules are different than for Go, so cannot use strconv.Unquote.
+func unquote(s []byte) (t string, ok bool) {
+	s, ok = unquoteBytes(s)
+	t = string(s)
+	return
+}
+
+func unquoteBytes(s []byte) (t []byte, ok bool) {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return
+	}
+	s = s[1 : len(s)-1]
+
+	// Check for unusual characters. If there are none,
+	// then no unquoting is needed, so return a slice of the
+	// original bytes.
+	r := 0
+	for r < len(s) {
+		c := s[r]
+		if c == '\\' || c == '"' || c < ' ' {
+			break
+		}
+		if c < utf8.RuneSelf {
+			r++
+			continue
+		}
+		rr, size := utf8.DecodeRune(s[r:])
+		if rr == utf8.RuneError && size == 1 {
+			break
+		}
+		r += size
+	}
+	if r == len(s) {
+		return s, true
+	}
+
+	b := make([]byte, len(s)+2*utf8.UTFMax)
+	w := copy(b, s[0:r])
+	for r < len(s) {
+		// Out of room?  Can only happen if s is full of
+		// malformed UTF-8 and we're replacing each
+		// byte with RuneError.
+		if w >= len(b)-2*utf8.UTFMax {
+			nb := make([]byte, (len(b)+utf8.UTFMax)*2)
+			copy(nb, b[0:w])
+			b = nb
+		}
+		switch c := s[r]; {
+		case c == '\\':
+			r++
+			if r >= len(s) {
+				return
+			}
+			switch s[r] {
+			default:
+				return
+			case '"', '\\', '/', '\'':
+				b[w] = s[r]
+				r++
+				w++
+			case 'b':
+				b[w] = '\b'
+				r++
+				w++
+			case 'f':
+				b[w] = '\f'
+				r++
+				w++
+			case 'n':
+				b[w] = '\n'
+				r++
+				w++
+			case 'r':
+				b[w] = '\r'
+				r++
+				w++
+			case 't':
+				b[w] = '\t'
+				r++
+				w++
+			case 'u':
+				r--
+				rr := getu4(s[r:])
+				if rr < 0 {
+					return
+				}
+				r += 6
+				if utf16.IsSurrogate(rr) {
+					rr1 := getu4(s[r:])
+					if dec := utf16.DecodeRune(rr, rr1); dec != unicode.ReplacementChar {
+						// A valid pair; consume.
+						r += 6
+						w += utf8.EncodeRune(b[w:], dec)
+						break
+					}
+					// Invalid surrogate; fall back to replacement rune.
+					rr = unicode.ReplacementChar
+				}
+				w += utf8.EncodeRune(b[w:], rr)
+			}
+
+		// Quote, control characters are invalid.
+		case c == '"', c < ' ':
+			return
+
+		// ASCII
+		case c < utf8.RuneSelf:
+			b[w] = c
+			r++
+			w++
+
+		// Coerce to well-formed UTF-8.
+		default:
+			rr, size := utf8.DecodeRune(s[r:])
+			r += size
+			w += utf8.EncodeRune(b[w:], rr)
+		}
+	}
+	return b[0:w], true
+}


### PR DESCRIPTION
Vendoring-only change. Adding [go-kit logger](https://godoc.org/github.com/go-kit/kit/log) library.

Example logs output from the main process will look like:

```
time=2016-07-22T06:07:34Z operation=Install seq=0 event=++start
time=2016-07-22T06:07:34Z operation=Install seq=0 event="created data dir" path=/var/lib/azure/custom-script
time=2016-07-22T06:07:34Z operation=Install seq=0 event=installed
time=2016-07-22T06:07:34Z operation=Install seq=0 event=--end
time=2016-07-22T06:07:35Z operation=Enable seq=0 event=++start
time=2016-07-22T06:07:35Z operation=Enable seq=0 event="parsed settings"
time=2016-07-22T06:07:35Z operation=Enable seq=0 event="comparing seqnum"
time=2016-07-22T06:07:35Z operation=Enable seq=0 event="seqnum saved" path=/var/lib/azure/custom-script/seqnum
time=2016-07-22T06:07:35Z operation=Enable seq=0 event="created output directory" path=/var/lib/azure/custom-script/download/0
time=2016-07-22T06:07:35Z operation=Enable seq=0 files=0
time=2016-07-22T06:07:35Z operation=Enable seq=0 event="executing command" output=/var/lib/azure/custom-script/download/0
time=2016-07-22T06:07:35Z operation=Enable seq=0 event="executed command" output=/var/lib/azure/custom-script/download/0
time=2016-07-22T06:07:35Z operation=Enable seq=0 event=enabled
time=2016-07-22T06:07:35Z operation=Enable seq=0 event=--end
```

- github.com/go-kit/kit/log
    - github.com/go-logfmt/logfmt
        - github.com/kr/logfmt
    - github.com/go-stack/stack

Signed-off-by: Ahmet Alp Balkan