### PR TITLE
seqnum: update IsSmallerThan→IsSmallerOrEqualThan

### DIFF
--- a/seqnum/seqnum.go
+++ b/seqnum/seqnum.go
@@ -24,16 +24,17 @@ func Set(path string, num int) error {
 	return errors.Wrap(ioutil.WriteFile(path, b, chmod), "seqnum: failed to write")
 }
 
-// IsSmallerThan returns if the sequence number stored at path is smaller than
-// the provided num. If no number is stored, returns true and no error.
-func IsSmallerThan(path string, num int) (bool, error) {
+// IsSmallerOrEqualThan returns if the sequence number stored at path is smaller
+// or equal than the provided num. If no number is stored, returns false and no
+// error.
+func IsSmallerOrEqualThan(path string, num int) (bool, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return true, nil
+			return false, nil
 		}
 		return false, errors.Wrap(err, "seqnum: failed to read")
 	}
 	stored, err := strconv.Atoi(string(b))
-	return stored < num, errors.Wrapf(err, "seqnum: cannot parse number %q", b)
+	return stored <= num, errors.Wrapf(err, "seqnum: cannot parse number %q", b)
 }

--- a/seqnum/seqnum.go
+++ b/seqnum/seqnum.go
@@ -24,7 +24,7 @@ func Set(path string, num int) error {
 	return errors.Wrap(ioutil.WriteFile(path, b, chmod), "seqnum: failed to write")
 }
 
-// IsSmallerOrEqualThan returns if the sequence number stored at path is smaller
+// IsSmallerOrEqualThan returns true if the sequence number stored at path is smaller
 // or equal than the provided num. If no number is stored, returns false and no
 // error.
 func IsSmallerOrEqualThan(path string, num int) (bool, error) {

--- a/seqnum/seqnum_test.go
+++ b/seqnum/seqnum_test.go
@@ -29,6 +29,7 @@ func TestSet_newFile(t *testing.T) {
 	require.Nil(t, err)
 	f.Close()
 	fp := f.Name()
+	require.Nil(t, os.Remove(fp)) // delete file on purpose
 	defer os.RemoveAll(fp)
 
 	require.Nil(t, seqnum.Set(fp, 1))
@@ -59,47 +60,57 @@ func TestSet_truncates(t *testing.T) {
 	require.Equal(t, "2", string(b))
 }
 
-func TestSetGet(t *testing.T) {
+func TestIsSmallerOrEqualThan(t *testing.T) {
 	fp := testFile(t, 0600)
 	defer os.RemoveAll(fp)
 
-	require.Nil(t, seqnum.Set(fp, 1))
+	require.Nil(t, seqnum.Set(fp, 0)) // SET 0
 
-	b, err := seqnum.IsSmallerThan(fp, 2)
+	b, err := seqnum.IsSmallerOrEqualThan(fp, 0)
 	require.Nil(t, err)
-	require.True(t, b, "1<2")
+	require.True(t, b, "0≤0")
 
-	b, err = seqnum.IsSmallerThan(fp, 1)
+	b, err = seqnum.IsSmallerOrEqualThan(fp, 1)
 	require.Nil(t, err)
-	require.False(t, b, "1≮1")
+	require.True(t, b, "0≤1")
 
-	b, err = seqnum.IsSmallerThan(fp, 0)
+	require.Nil(t, seqnum.Set(fp, 1)) // SET 1
+
+	b, err = seqnum.IsSmallerOrEqualThan(fp, 0)
 	require.Nil(t, err)
-	require.False(t, b, "1≮0")
+	require.False(t, b, "1≰0")
+
+	b, err = seqnum.IsSmallerOrEqualThan(fp, 1)
+	require.Nil(t, err)
+	require.True(t, b, "1≤1")
+
+	b, err = seqnum.IsSmallerOrEqualThan(fp, 2)
+	require.Nil(t, err)
+	require.True(t, b, "1≤2")
 }
 
-func TestIsSmallerThan_nonExistingFile(t *testing.T) {
-	b, err := seqnum.IsSmallerThan("/non/existing/path", 0)
+func TestIsSmallerOrEqualThan_nonExistingFile(t *testing.T) {
+	b, err := seqnum.IsSmallerOrEqualThan("/non/existing/path", 0)
 	require.Nil(t, err)
-	require.True(t, b, "non-existing file is always smaller than specified seqnum")
+	require.False(t, b, "non-existing file is always smaller than specified seqnum")
 }
 
-func TestIsSmallerThan_readFailure(t *testing.T) {
+func TestIsSmallerOrEqualThan_readFailure(t *testing.T) {
 	fp := testFile(t, 0100) // remove read permissions
 	defer os.RemoveAll(fp)
 
-	_, err := seqnum.IsSmallerThan(fp, 0)
+	_, err := seqnum.IsSmallerOrEqualThan(fp, 0)
 	require.NotNil(t, err, "read should have failed")
 	require.Contains(t, err.Error(), "seqnum: failed to read")
 }
 
-func TestIsSmallerThan_parseError(t *testing.T) {
+func TestIsSmallerOrEqualThan_parseError(t *testing.T) {
 	fp := testFile(t, 0600)
 	defer os.RemoveAll(fp)
 
 	require.Nil(t, ioutil.WriteFile(fp, []byte{'a'}, 0700))
 
-	_, err := seqnum.IsSmallerThan(fp, 0)
+	_, err := seqnum.IsSmallerOrEqualThan(fp, 0)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "seqnum: cannot parse number \"a\"")
 }


### PR DESCRIPTION
This package was designed to be used to make sure we do not
execute same or lower sequence numbers more than once. Changing
the method accordingly to be more useful in that regard.

Signed-off-by: Ahmet Alp Balkan