### PR TITLE
travis.yml: add integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,15 @@ install:
   - sudo add-apt-repository ppa:duggan/bats --yes
   - sudo apt-get update -qq
   - sudo apt-get install -qq bats
+  - curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
+  - sudo apt-get install -qqy nodejs
+  - sudo npm install -g npm
+  - sudo npm install -g azure-cli
   - go get -u github.com/golang/lint/golint
 before_script:
   - docker version
   - docker info
+  - azure -v
 script:
   - test -z "$(gofmt -s -l -w $(find . -type f -name '*.go' -not -path './vendor/*') | tee /dev/stderr)"
   - test -z "$(golint . | tee /dev/stderr)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ script:
   - test -z "$(golint . | tee /dev/stderr)"
   - test -z "$(go vet -v $(go list ./... | grep -v '/vendor/') | tee /dev/stderr)"
   - go list ./... | grep -v '/vendor/' | xargs go test -v -cover
+  - make binary
   - bats integration-test/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
-sudo: false
+sudo: true
+services:
+ - docker
 language: go
 go: go1.6
 install:
+  - sudo add-apt-repository ppa:duggan/bats --yes
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq bats
   - go get -u github.com/golang/lint/golint
+before_script:
+  - docker version
+  - docker info
 script:
   - test -z "$(gofmt -s -l -w $(find . -type f -name '*.go' -not -path './vendor/*') | tee /dev/stderr)"
   - test -z "$(golint . | tee /dev/stderr)"
   - test -z "$(go vet -v $(go list ./... | grep -v '/vendor/') | tee /dev/stderr)"
   - go list ./... | grep -v '/vendor/' | xargs go test -v -cover
+  - bats integration-test/test

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ binary: clean
 	  -ldflags "-X main.BuildDate=`date -u --rfc-3339=seconds 2> /dev/null | sed -e 's/ /T/'` \
 	  -X main.Version=`<./VERSION` \
 	  -X main.GitCommit=`git rev-parse --short HEAD` \
-	  -X main.State=`if [[ -n $$(git status --porcelain) ]]; then echo 'dirty'; fi`" \
+	  -X main.State=`if [ -n "$$(git status --porcelain)" ]; then echo 'dirty'; fi`" \
 	  -o $(BINDIR)/$(BIN) . 
 clean:
 	rm -rf "$(BINDIR)"


### PR DESCRIPTION
:warning::warning: this is expected  to fail until #24 and #32 are merged. once they are in, I will rebase and we should start getting CI running our integration test suite as well.

-----

- change sudo:true so that we can get a Docker engine
    - this will slow down the time to get a test box (a few mins)
      but it should be fine
- add bats in 'install'
- print docker info prior to testing
- execute bats