### PR TITLE
download: plumb logger for logging retries

### DIFF
--- a/cmds.go
+++ b/cmds.go
@@ -132,7 +132,7 @@ func downloadFiles(ctx *log.Context, dir string, cfg handlerSettings) error {
 	for i, f := range cfg.FileURLs {
 		ctx := ctx.With("file", i)
 		ctx.Log("event", "download start")
-		if err := downloadAndProcessURL(f, dir, cfg.StorageAccountName, cfg.StorageAccountKey); err != nil {
+		if err := downloadAndProcessURL(ctx, f, dir, cfg.StorageAccountName, cfg.StorageAccountKey); err != nil {
 			ctx.Log("event", "download failed", "error", err)
 			return errors.Wrapf(err, "failed to download file[%d]", i)
 		}

--- a/download/save.go
+++ b/download/save.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 )
 
@@ -15,14 +16,14 @@ const (
 // given file. Directory of dst is not created by this function. If a file at
 // dst exists, it will be truncated. If a new file is created, mode is used to
 // set the permission bits. Written number of bytes are returned on success.
-func SaveTo(d Downloader, dst string, mode os.FileMode) (int64, error) {
+func SaveTo(ctx *log.Context, d Downloader, dst string, mode os.FileMode) (int64, error) {
 	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, mode)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to open file for writing")
 	}
 	defer f.Close()
 
-	body, err := WithRetries(d, ActualSleep)
+	body, err := WithRetries(ctx, d, ActualSleep)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to download file")
 	}

--- a/download/save_test.go
+++ b/download/save_test.go
@@ -19,7 +19,7 @@ func TestSaveTo_invalidDir(t *testing.T) {
 
 	d := download.NewURLDownload(srv.URL + "/bytes/65536")
 
-	_, err := download.SaveTo(d, "/nonexistent-dir/dst", 0600)
+	_, err := download.SaveTo(nopLog(), d, "/nonexistent-dir/dst", 0600)
 	require.Contains(t, err.Error(), "failed to open file for writing")
 }
 
@@ -33,7 +33,7 @@ func TestSave(t *testing.T) {
 
 	d := download.NewURLDownload(srv.URL + "/bytes/65536")
 	path := filepath.Join(dir, "test-file")
-	n, err := download.SaveTo(d, path, 0600)
+	n, err := download.SaveTo(nopLog(), d, path, 0600)
 	require.Nil(t, err)
 	require.EqualValues(t, 65536, n)
 
@@ -52,9 +52,9 @@ func TestSave_truncates(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	path := filepath.Join(dir, "test-file")
-	_, err = download.SaveTo(download.NewURLDownload(srv.URL+"/bytes/65536"), path, 0600)
+	_, err = download.SaveTo(nopLog(), download.NewURLDownload(srv.URL+"/bytes/65536"), path, 0600)
 	require.Nil(t, err)
-	_, err = download.SaveTo(download.NewURLDownload(srv.URL+"/bytes/128"), path, 0777)
+	_, err = download.SaveTo(nopLog(), download.NewURLDownload(srv.URL+"/bytes/128"), path, 0777)
 	require.Nil(t, err)
 
 	fi, err := os.Stat(path)
@@ -74,7 +74,7 @@ func TestSave_largeFile(t *testing.T) {
 	size := 1024 * 1024 * 128 // 128 mb
 
 	path := filepath.Join(dir, "large-file")
-	n, err := download.SaveTo(download.NewURLDownload(srv.URL+"/bytes/"+fmt.Sprintf("%d", size)), path, 0600)
+	n, err := download.SaveTo(nopLog(), download.NewURLDownload(srv.URL+"/bytes/"+fmt.Sprintf("%d", size)), path, 0600)
 	require.Nil(t, err)
 	require.EqualValues(t, size, n)
 

--- a/files.go
+++ b/files.go
@@ -10,13 +10,14 @@ import (
 	"github.com/Azure/custom-script-extension-linux/blobutil"
 	"github.com/Azure/custom-script-extension-linux/download"
 	"github.com/Azure/custom-script-extension-linux/preprocess"
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 )
 
 // downloadAndProcessURL downloads using the specified downloader and saves it to the
 // specified existing directory, which must be the path to the saved file. Then
 // it post-processes file based on heuristics.
-func downloadAndProcessURL(url, downloadDir, storageAccountName, storageAccountKey string) error {
+func downloadAndProcessURL(ctx *log.Context, url, downloadDir, storageAccountName, storageAccountKey string) error {
 	fn, err := urlToFileName(url)
 	if err != nil {
 		return err
@@ -29,7 +30,7 @@ func downloadAndProcessURL(url, downloadDir, storageAccountName, storageAccountK
 
 	fp := filepath.Join(downloadDir, fn)
 	const mode = 0500 // we assume users download scripts to execute
-	if _, err := download.SaveTo(dl, fp, mode); err != nil {
+	if _, err := download.SaveTo(ctx, dl, fp, mode); err != nil {
 		return err
 	}
 

--- a/files_test.go
+++ b/files_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ahmetalpbalkan/go-httpbin"
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -109,7 +110,8 @@ func Test_downloadAndProcessURL(t *testing.T) {
 	require.Nil(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	err = downloadAndProcessURL(srv.URL+"/bytes/256", tmpDir, "", "")
+	err = downloadAndProcessURL(log.NewContext(log.NewNopLogger()),
+		srv.URL+"/bytes/256", tmpDir, "", "")
 	require.Nil(t, err)
 
 	fp := filepath.Join(tmpDir, "256")


### PR DESCRIPTION
Plumbing logger reference into the download package so that
users can get more visibility into the download failures
during the retries by looking at the logs.

# Example output with this:
```log
time=2016-07-26T22:28:51Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 files=1
time=2016-07-26T22:28:51Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 event="download start"
time=2016-07-26T22:28:52Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=0 error="unexpected status code: got=404 expected=200"
time=2016-07-26T22:28:52Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=0 sleep=3s
time=2016-07-26T22:28:55Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=1 error="unexpected status code: got=404 expected=200"
time=2016-07-26T22:28:55Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=1 sleep=6s
time=2016-07-26T22:29:02Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=2 error="unexpected status code: got=404 expected=200"
time=2016-07-26T22:29:02Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=2 sleep=12s
time=2016-07-26T22:29:14Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=3 error="unexpected status code: got=404 expected=200"
time=2016-07-26T22:29:14Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=3 sleep=24s
time=2016-07-26T22:29:39Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=4 error="unexpected status code: got=404 expected=200"
time=2016-07-26T22:29:39Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=4 sleep=48s
time=2016-07-26T22:30:27Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=5 error="unexpected status code: got=404 expected=200"
time=2016-07-26T22:30:27Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=5 sleep=1m36s
time=2016-07-26T22:32:04Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 retry=6 error="unexpected status code: got=404 expected=200"
time=2016-07-26T22:32:04Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 file=0 event="download failed" error="failed to download file: unexpected status code: got=404 expected=200"
time=2016-07-26T22:32:04Z version=v2.0.0-beta/git@c5044e0-dirty operation=enable seq=0 event="failed to handle" error="processing file downloads failed: failed to download file[0]: failed to download file: unexpected status code: got=404 expected=200"
```