### PR TITLE
integration-test: add storage tests for blobs as fileUris

### DIFF
--- a/download/blob_test.go
+++ b/download/blob_test.go
@@ -89,9 +89,9 @@ func Test_blobDownload_fails_urlNotFound(t *testing.T) {
 
 func Test_blobDownload_actualBlob(t *testing.T) {
 	acct := os.Getenv("AZURE_STORAGE_ACCOUNT")
-	key := os.Getenv("AZURE_STORAGE_KEY")
+	key := os.Getenv("AZURE_STORAGE_ACCESS_KEY")
 	if acct == "" || key == "" {
-		t.Skipf("Skipping: AZURE_STORAGE_ACCOUNT or AZURE_STORAGE_KEY not specified to run this test")
+		t.Skipf("Skipping: AZURE_STORAGE_ACCOUNT or AZURE_STORAGE_ACCESS_KEY not specified to run this test")
 	}
 	base := storage.DefaultBaseURL
 

--- a/integration-test/test/basic.bats
+++ b/integration-test/test/basic.bats
@@ -8,6 +8,12 @@ load test_helper
     [ "$status" -eq 0 ]
 }
 
+@test "meta: azure cli is installed" {
+    run azure -v
+    echo "$output">&2
+    [ "$status" -eq 0 ]
+}
+
 @test "meta: can build the test container image" {
     run build_docker_image
     echo "$output"

--- a/integration-test/test/handler-commands.bats
+++ b/integration-test/test/handler-commands.bats
@@ -152,7 +152,7 @@ teardown(){
     [[ "$diff" == *"A /var/lib/azure/custom-script/download/0/$blob2"* ]] # file downloaded
 
     # compare checksum
-    existing=$(cat "$tmp" | md5 -q)
+    existing=$(md5 -q "$tmp")
     echo "Local file checksum: $existing"
     got=$(container_read_file "/var/lib/azure/custom-script/download/0/$blob1" | md5 -q)
     echo "Downloaded file checksum: $got"

--- a/integration-test/test/handler-commands.bats
+++ b/integration-test/test/handler-commands.bats
@@ -108,6 +108,57 @@ teardown(){
     [[ "$diff" == *"A /b.txt"* ]] # created by script.sh
 }
 
+@test "handler command: enable - download files from storage account" {
+    if [[ -z  "$AZURE_STORAGE_ACCOUNT" ]] || [[ -z  "$AZURE_STORAGE_ACCESS_KEY" ]]; then
+        skip "AZURE_STORAGE_ACCOUNT or AZURE_STORAGE_ACCESS_KEY not specified"
+    fi
+
+    # make random file
+    tmp="$(mktemp)"
+    dd if=/dev/urandom of="$tmp" bs=1k count=512
+
+    # upload files to a storage container
+    cnt="testcontainer"
+    blob1="blob1-$RANDOM"
+    blob2="blob2-$RANDOM"
+    azure storage container show  "$cnt" 1>/dev/null ||
+        azure storage container create "$cnt" 1>/dev/null && echo "Azure Storage container created">&2
+    azure storage blob upload -f "$tmp" "$cnt" "$blob1" 1>/dev/null  # upload blob1
+    azure storage blob upload -f "$tmp" "$cnt" "$blob2" 1>/dev/null # upload blob2
+
+    blob1_url="http://$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$cnt/$blob1" # over http
+    blob2_url="https://$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$cnt/$blob2" # over https
+
+    mk_container sh -c "fake-waagent install && fake-waagent enable && wait-for-enable" # add sleep for enable to finish in the background
+    # download an external script and run it
+    push_settings "{
+        \"fileUris\": [
+                \"$blob1_url\",
+                \"$blob2_url\"
+        ],
+        \"commandToExecute\":\"date\"
+        }" "{
+            \"storageAccountName\": \"$AZURE_STORAGE_ACCOUNT\",
+            \"storageAccountKey\": \"$AZURE_STORAGE_ACCESS_KEY\"
+        }"
+    run start_container
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'file=0 event="download complete"'* ]]
+    [[ "$output" == *'file=1 event="download complete"'* ]]
+
+    diff="$(container_diff)"; echo "$diff"
+    [[ "$diff" == *"A /var/lib/azure/custom-script/download/0/$blob1"* ]] # file downloaded
+    [[ "$diff" == *"A /var/lib/azure/custom-script/download/0/$blob2"* ]] # file downloaded
+
+    # compare checksum
+    existing=$(cat "$tmp" | md5 -q)
+    echo "Local file checksum: $existing"
+    got=$(container_read_file "/var/lib/azure/custom-script/download/0/$blob1" | md5 -q)
+    echo "Downloaded file checksum: $got"
+    [[ "$existing" == "$got" ]]
+}
+
 @test "handler command: uninstall - deletes the data dir" {
     run in_container sh -c \
         "fake-waagent install && fake-waagent uninstall"


### PR DESCRIPTION
When AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_ACCESS_KEY passed,
we now have a scenario that runs by uploading two 512k files to
Azure Blob Storage and configures extension to download it.

We verify by checking test container fs diff to see files are
downloaded and we verify checksum on one of the files.