### PR TITLE
integration-test: fix for daemonized 'enable' cmd

### DIFF
--- a/integration-test/env/wait-for-enable
+++ b/integration-test/env/wait-for-enable
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script exists because custom-script-shim will detach the enable command
+# into background and when that happens the custom-script shim will exit,
+# causing test container to exit as its entrypoint has exited. So we use this
+# to wait indefinitely until enable background process disappears from ps output.
+
+log(){ echo "[wait] time=$(date --rfc-3339=s | sed 's/ /T/') $@">&2; }
+
+bin="bin/custom-script-extension"
+while true; do
+    out="$(ps aux)"
+    if [[ "$out" == **"$bin"** ]]; then
+        log "'$bin' still running in the background..."
+        sleep .5
+    else
+        log "'$bin' process exited"
+        exit 0
+    fi
+done

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -15,7 +15,8 @@ RUN mkdir -p /var/lib/waagent && \
 # Copy the test environment
 WORKDIR /var/lib/waagent
 COPY integration-test/env/ .
-RUN ln -s /var/lib/waagent/fake-waagent /sbin/fake-waagent
+RUN ln -s /var/lib/waagent/fake-waagent /sbin/fake-waagent && \
+        ln -s /var/lib/waagent/wait-for-enable /sbin/wait-for-enable
 
 # Copy the handler files
 COPY HandlerManifest.json ./Extension/


### PR DESCRIPTION
Since #39 is adding a shim that daemonizes 'enable' command and
exits and shim is the entrypoint of the container command, Docker
will kill the container when that entrypoint exits (will not wait
background process to finish). This adds a `wait-for-enable` command
that we use in integration tests. It runs inside the test container
and loops indefinitely until the background process exits.

Also by detaching enable cmd from the process tree, we lose ability
to get its exitcode, but we will still keep validating its output so we're good.

Should be merged once #39 is in.