### PR TITLE
wait-for-enable: add initial 1s delay

### DIFF
--- a/integration-test/env/wait-for-enable
+++ b/integration-test/env/wait-for-enable
@@ -7,6 +7,7 @@
 
 log(){ echo "[wait] time=$(date --rfc-3339=s | sed 's/ /T/') $@">&2; }
 
+sleep 1
 bin="bin/custom-script-extension"
 while true; do
     out="$(ps aux)"


### PR DESCRIPTION
Inside the container when we invoke `nohup [...] &` it immediately
returns and `wait-for-enable` starts checking `ps aux` for extension
binary. However since travis environment is not fast, `wait-for-enable`
exited immediately once before the process started.

Adding a 1s delay while polling for exit of extension process should
solve this problem.

cc: @boumenot