### PR TITLE
EDP: add `make bundle` and manifest.xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ BIN=custom-script-extension
 BUNDLEDIR=bundle
 BUNDLE=custom-script-extension.zip
 
+bundle: clean binary
+	@mkdir -p $(BUNDLEDIR)
+	zip ./$(BUNDLEDIR)/$(BUNDLE) ./$(BINDIR)/$(BIN)
+	zip ./$(BUNDLEDIR)/$(BUNDLE) ./$(BINDIR)/custom-script-shim
+	zip -j ./$(BUNDLEDIR)/$(BUNDLE) ./HandlerManifest.json
 binary: clean
 	if [ -z "$$GOPATH" ]; then \
 	  echo "GOPATH is not set"; \
@@ -15,11 +20,6 @@ binary: clean
 	  -X main.State=`if [[ -n $$(git status --porcelain) ]]; then echo 'dirty'; fi`" \
 	  -o $(BINDIR)/$(BIN) . 
 	cp ./misc/custom-script-shim ./$(BINDIR)
-bundle: clean binary
-	@mkdir -p $(BUNDLEDIR)
-	zip ./$(BUNDLEDIR)/$(BUNDLE) ./$(BINDIR)/$(BIN)
-	zip ./$(BUNDLEDIR)/$(BUNDLE) ./$(BINDIR)/custom-script-shim
-	zip -j ./$(BUNDLEDIR)/$(BUNDLE) ./HandlerManifest.json
 clean:
 	rm -rf "$(BINDIR)" "$(BUNDLEDIR)"
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 BINDIR=bin
 BIN=custom-script-extension
+BUNDLEDIR=bundle
+BUNDLE=custom-script-extension.zip
 
 binary: clean
 	if [ -z "$$GOPATH" ]; then \
@@ -12,7 +14,13 @@ binary: clean
 	  -X main.GitCommit=`git rev-parse --short HEAD` \
 	  -X main.State=`if [[ -n $$(git status --porcelain) ]]; then echo 'dirty'; fi`" \
 	  -o $(BINDIR)/$(BIN) . 
+	cp ./misc/custom-script-shim ./$(BINDIR)
+bundle: clean binary
+	@mkdir -p $(BUNDLEDIR)
+	zip ./$(BUNDLEDIR)/$(BUNDLE) ./$(BINDIR)/$(BIN)
+	zip ./$(BUNDLEDIR)/$(BUNDLE) ./$(BINDIR)/custom-script-shim
+	zip -j ./$(BUNDLEDIR)/$(BUNDLE) ./HandlerManifest.json
 clean:
-	rm -rf "$(BINDIR)"
+	rm -rf "$(BINDIR)" "$(BUNDLEDIR)"
 
-.PHONY: clean
+.PHONY: clean binary

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
+  <ProviderNameSpace>Microsoft.Azure.Extensions</ProviderNameSpace>
+  <Type>CustomScriptForLinux</Type>
+  <Version>2.0.0</Version>
+  <Label>Microsoft Azure Custom Script Extension for Linux Virtual Machines</Label>
+  <HostingResources>VmRole</HostingResources>
+  <MediaLink></MediaLink>
+  <Description>Microsoft Azure Custom Script Extension for Linux Virtual Machines</Description>
+  <IsInternalExtension>true</IsInternalExtension>
+  <Eula>https://github.com/Azure/custom-script-extension-linux/blob/master/LICENSE</Eula>
+  <PrivacyUri>http://www.microsoft.com/privacystatement/en-us/OnlineServices/Default.aspx</PrivacyUri>
+  <HomepageUri>https://github.com/Azure/custom-script-extension-linux</HomepageUri>
+  <IsJsonExtension>true</IsJsonExtension>
+  <SupportedOS>Linux</SupportedOS>
+  <CompanyName>Microsoft</CompanyName>
+  <!--%REGIONS%-->
+</ExtensionImage>


### PR DESCRIPTION
Extension deployment pipeline requirements.

- Added a manifest.xml (which has a version number that should be
  kept in sync with `./VERSION` file)
- Added a `make bundle` command which should produce a `bundle/custom-script-extension.zip`

cc: @boumenot