### PR TITLE
integration-test: remove dependency to gist

### DIFF
--- a/integration-test/test/handler-commands.bats
+++ b/integration-test/test/handler-commands.bats
@@ -90,7 +90,7 @@ teardown(){
     # download an external script and run it
     push_settings '{
         "fileUris": [
-                "https://gist.github.com/anonymous/8c83af2923ec8dd4a92309594a6c90d7/raw/f26c2cbf68e22d42f703b78f8a4562c5c8e43ba7/script.sh"
+                "https://github.com/Azure/custom-script-extension-linux/raw/master/integration-test/testdata/script.sh"
         ],
         "commandToExecute":"./script.sh"
         }'

--- a/integration-test/testdata/script.sh
+++ b/integration-test/testdata/script.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+touch /b.txt


### PR DESCRIPTION
Checking in the external test file. The CI is supposed to fail and succeed back again once merged.

This is less dependent on github gist and more on github's URL redirection for raw files and the source tree structure now.