### PR TITLE
Do not rely on SeqNo in HandlerEnvironment.xml

### DIFF
--- a/main/cmds_test.go
+++ b/main/cmds_test.go
@@ -38,9 +38,9 @@ func Test_commands_shouldReportStatus(t *testing.T) {
 
 func Test_checkAndSaveSeqNum_fails(t *testing.T) {
 	// pass in invalid seqnum format
-	_, err := checkAndSaveSeqNum(log.NewNopLogger(), "not-an-int", "/un/used")
+	_, err := checkAndSaveSeqNum(log.NewNopLogger(), 0, "/non/existing/dir")
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), `failed to parse seqnum: "not-an-int"`)
+	require.Contains(t, err.Error(), `failed to save the sequence number`)
 }
 
 func Test_checkAndSaveSeqNum(t *testing.T) {
@@ -52,27 +52,27 @@ func Test_checkAndSaveSeqNum(t *testing.T) {
 	nop := log.NewNopLogger()
 
 	// no sequence number, 0 comes in.
-	shouldExit, err := checkAndSaveSeqNum(nop, "0", fp)
+	shouldExit, err := checkAndSaveSeqNum(nop, 0, fp)
 	require.Nil(t, err)
 	require.False(t, shouldExit)
 
 	// file=0, seq=0 comes in. (should exit)
-	shouldExit, err = checkAndSaveSeqNum(nop, "0", fp)
+	shouldExit, err = checkAndSaveSeqNum(nop, 0, fp)
 	require.Nil(t, err)
 	require.True(t, shouldExit)
 
 	// file=0, seq=1 comes in.
-	shouldExit, err = checkAndSaveSeqNum(nop, "1", fp)
+	shouldExit, err = checkAndSaveSeqNum(nop, 1, fp)
 	require.Nil(t, err)
 	require.False(t, shouldExit)
 
 	// file=1, seq=1 comes in. (should exit)
-	shouldExit, err = checkAndSaveSeqNum(nop, "1", fp)
+	shouldExit, err = checkAndSaveSeqNum(nop, 1, fp)
 	require.Nil(t, err)
 	require.True(t, shouldExit)
 
 	// file=1, seq=0 comes in. (should exit)
-	shouldExit, err = checkAndSaveSeqNum(nop, "1", fp)
+	shouldExit, err = checkAndSaveSeqNum(nop, 1, fp)
 	require.Nil(t, err)
 	require.True(t, shouldExit)
 }

--- a/main/main.go
+++ b/main/main.go
@@ -39,17 +39,21 @@ func main() {
 		ctx.Log("message", "failed to parse handlerenv", "error", err)
 		os.Exit(1)
 	}
-	ctx = ctx.With("seq", hEnv.SeqNo)
+	seqNum, err := vmextension.FindSeqNum(hEnv.HandlerEnvironment.ConfigFolder)
+	if err != nil {
+		ctx.Log("messsage", "failed to find sequence number", "error", err)
+	}
+	ctx = ctx.With("seq", seqNum)
 
 	// execute the subcommand
 	ctx.Log("event", "start")
-	reportStatus(ctx, hEnv, status.StatusTransitioning, cmd, "")
-	if err := cmd.f(ctx, hEnv); err != nil {
+	reportStatus(ctx, hEnv, seqNum, status.StatusTransitioning, cmd, "")
+	if err := cmd.f(ctx, hEnv, seqNum); err != nil {
 		ctx.Log("event", "failed to handle", "error", err)
-		reportStatus(ctx, hEnv, status.StatusError, cmd, err.Error())
+		reportStatus(ctx, hEnv, seqNum, status.StatusError, cmd, err.Error())
 		os.Exit(1)
 	}
-	reportStatus(ctx, hEnv, status.StatusSuccess, cmd, "")
+	reportStatus(ctx, hEnv, seqNum, status.StatusSuccess, cmd, "")
 	ctx.Log("event", "end")
 }
 

--- a/main/status.go
+++ b/main/status.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"strconv"
-
 	"github.com/Azure/azure-docker-extension/pkg/vmextension"
 	"github.com/Azure/azure-docker-extension/pkg/vmextension/status"
 	"github.com/go-kit/kit/log"
@@ -14,14 +12,13 @@ import (
 // status.
 //
 // If an error occurs reporting the status, it will be logged and returned.
-func reportStatus(ctx *log.Context, hEnv vmextension.HandlerEnvironment, t status.Type, c cmd, msg string) error {
+func reportStatus(ctx *log.Context, hEnv vmextension.HandlerEnvironment, seqNum int, t status.Type, c cmd, msg string) error {
 	if !c.shouldReportStatus {
 		ctx.Log("status", "not reported for operation (by design)")
 		return nil
 	}
 	s := status.NewStatus(t, c.name, statusMsg(c, t, msg))
-	seq, _ := strconv.Atoi(hEnv.SeqNo)
-	if err := s.Save(hEnv.HandlerEnvironment.StatusFolder, seq); err != nil {
+	if err := s.Save(hEnv.HandlerEnvironment.StatusFolder, seqNum); err != nil {
 		ctx.Log("event", "failed to save handler status", "error", err)
 		return errors.Wrap(err, "failed to save handler status")
 	}

--- a/main/status_test.go
+++ b/main/status_test.go
@@ -24,10 +24,10 @@ func Test_statusMsg(t *testing.T) {
 }
 
 func Test_reportStatus_fails(t *testing.T) {
-	fakeEnv := vmextension.HandlerEnvironment{SeqNo: "1"}
+	fakeEnv := vmextension.HandlerEnvironment{}
 	fakeEnv.HandlerEnvironment.StatusFolder = "/non-existing/dir/"
 
-	err := reportStatus(log.NewContext(log.NewNopLogger()), fakeEnv, status.StatusSuccess, cmdEnable, "")
+	err := reportStatus(log.NewContext(log.NewNopLogger()), fakeEnv, 1, status.StatusSuccess, cmdEnable, "")
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "failed to save handler status")
 }
@@ -37,10 +37,10 @@ func Test_reportStatus_fileExists(t *testing.T) {
 	require.Nil(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	fakeEnv := vmextension.HandlerEnvironment{SeqNo: "1"}
+	fakeEnv := vmextension.HandlerEnvironment{}
 	fakeEnv.HandlerEnvironment.StatusFolder = tmpDir
 
-	require.Nil(t, reportStatus(log.NewContext(log.NewNopLogger()), fakeEnv, status.StatusError, cmdEnable, "FOO ERROR"))
+	require.Nil(t, reportStatus(log.NewContext(log.NewNopLogger()), fakeEnv, 1, status.StatusError, cmdEnable, "FOO ERROR"))
 
 	path := filepath.Join(tmpDir, "1.status")
 	b, err := ioutil.ReadFile(path)
@@ -54,9 +54,9 @@ func Test_reportStatus_checksIfShouldBeReported(t *testing.T) {
 		require.Nil(t, err)
 		defer os.RemoveAll(tmpDir)
 
-		fakeEnv := vmextension.HandlerEnvironment{SeqNo: "2"}
+		fakeEnv := vmextension.HandlerEnvironment{}
 		fakeEnv.HandlerEnvironment.StatusFolder = tmpDir
-		require.Nil(t, reportStatus(log.NewContext(log.NewNopLogger()), fakeEnv, status.StatusSuccess, c, ""))
+		require.Nil(t, reportStatus(log.NewContext(log.NewNopLogger()), fakeEnv, 2, status.StatusSuccess, c, ""))
 
 		fp := filepath.Join(tmpDir, "2.status")
 		_, err = os.Stat(fp) // check if the .status file is there


### PR DESCRIPTION
Apparently waagent-2.0.x included a `SeqNo` field in HandlerEnvironment.xml
and 2.1.x removed it (it was not covered by the extensions spec). Other
extensions were using `vmextension.FindSeqNum(...)` method to locate the
highest sequence number.

Switching this handler to use it as well and refactoring a few methods
accordingly.

cc: @boumenot 