### PR TITLE
cmds: delete datadir before installing

### DIFF
--- a/integration-test/test/handler-commands.bats
+++ b/integration-test/test/handler-commands.bats
@@ -21,6 +21,16 @@ teardown(){
     [[ "$diff" = *"A /var/lib/azure/custom-script"* ]]
 }
 
+@test "handler command: install - cleans up data from the previous installation" {
+    mk_container sh -c "DIR=/var/lib/azure/custom-script; mkdir -p \$DIR && \
+        touch \$DIR/LEFTOVER && \
+        fake-waagent install"
+    run start_container
+    diff="$(container_diff)" && echo "$diff"
+    [[ "$diff" != *LEFTOVER* ]]
+}
+
+
 @test "handler command: enable - can process empty settings, but fails" {
     mk_container sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
     push_settings '' ''

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -39,6 +39,11 @@ func noop(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) error 
 }
 
 func install(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) error {
+	// remove dataDir first if exists to cleanup remnants of previous
+	// installations of the handler and captured images.
+	if err := os.RemoveAll(dataDir); err != nil {
+		return errors.Wrap(err, "failed to cleanup data dir prior to installation")
+	}
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		return errors.Wrap(err, "failed to create data dir")
 	}

--- a/misc/manifest.xml
+++ b/misc/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.Azure.Extensions</ProviderNameSpace>
   <Type>CustomScript</Type>
-  <Version>2.0.0</Version>
+  <Version>2.0.1</Version>
   <Label>Microsoft Azure Custom Script Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
Remove dataDir first if exists to cleanup remnants of previous
installations of the handler and captured images as the waagent
currently does not clean up this path.

Bumped version to v2.0.1 for release.

CC: @boumenot