### PR TITLE
cmd/enable: migrate old data dir on enable

### DIFF
--- a/main/cmds.go
+++ b/main/cmds.go
@@ -61,6 +61,13 @@ func uninstall(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) e
 }
 
 func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) error {
+	// for a few versions we need to migrate dataDirOld (introduced in v2.0.0) to
+	// dataDir (introduced in v2.0.1).
+	ctx.Log("message", "checking for state migration")
+	if err := migrateDataDir(ctx, dataDirOld, dataDir); err != nil {
+		return errors.Wrap(err, "state directory could not be migrated")
+	}
+
 	// parse the extension handler settings (not available prior to 'enable')
 	cfg, err := parseAndValidateSettings(ctx, h.HandlerEnvironment.ConfigFolder)
 	if err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -13,7 +13,8 @@ import (
 var (
 	// dataDir is where we store the downloaded files, logs and state for
 	// the extension handler
-	dataDir = "/var/lib/azure/custom-script"
+	dataDir    = "/var/lib/waagent/custom-script"
+	dataDirOld = "/var/lib/azure/custom-script" // used for migration, if present
 
 	// seqNumFile holds the processed highest sequence number to make
 	// sure we do not run the command more than once for the same sequence

--- a/main/migration.go
+++ b/main/migration.go
@@ -10,7 +10,7 @@ import (
 )
 
 // migrateDataDir moves oldDir to newDir, if oldDir exists by shelling out to
-// 'mv -rf'.
+// 'mv -f'.
 func migrateDataDir(ctx log.Logger, oldDir, newDir string) error {
 	ok, err := dirExists(oldDir)
 	if err != nil {

--- a/main/migration.go
+++ b/main/migration.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+)
+
+// migrateDataDir moves oldDir to newDir, if oldDir exists by shelling out to
+// 'mv -rf'.
+func migrateDataDir(ctx log.Logger, oldDir, newDir string) error {
+	ok, err := dirExists(oldDir)
+	if err != nil {
+		return errors.Wrap(err, "could not check old directory")
+	}
+	if !ok { // no need for migration
+		ctx.Log("message", "no old state found to migrate")
+		return nil
+	}
+	ctx.Log("message", "migrating old state")
+
+	var b bytes.Buffer
+	var bc = bufferCloser{&b}
+	stdout, stderr := bc, bc
+	if exitCode, err := Exec(fmt.Sprintf(`mv -f '%s'/* '%s'`, oldDir, newDir), "", stdout, stderr); err != nil {
+		output := string(b.Bytes())
+		return errors.Wrapf(err, "failed to migrate with mv, exit status: %d, output: %q", exitCode, output)
+	}
+	if err := os.RemoveAll(oldDir); err != nil {
+		return errors.Wrapf(err, "failed to delete old state directory %q", oldDir)
+	}
+	ctx.Log("message", "migrated old state with mv")
+	return nil
+}
+
+func dirExists(path string) (bool, error) {
+	s, err := os.Stat(path)
+	if err == nil {
+		return s.IsDir(), nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, errors.Wrap(err, "cannot check if directory exists")
+}
+
+type bufferCloser struct {
+	*bytes.Buffer
+}
+
+func (b bufferCloser) Close() error { return nil }

--- a/main/migration_test.go
+++ b/main/migration_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_dirExists(t *testing.T) {
+	ok, err := dirExists("/non-existing")
+	require.Nil(t, err)
+	require.False(t, ok)
+
+	d := tempDir(t)
+	defer os.RemoveAll(d)
+	ok, err = dirExists(d)
+	require.Nil(t, err)
+	require.True(t, ok)
+}
+
+func tempDir(t *testing.T) string {
+	d, err := ioutil.TempDir("", "")
+	require.Nil(t, err, "failed to create test dir")
+	return d
+}
+
+func Test_migrateDataDir_noPriorData(t *testing.T) {
+	err := migrateDataDir(log.NewNopLogger(), "/non-existing", "/tmp/foo")
+	require.Nil(t, err)
+}
+
+func Test_migrateDataDir(t *testing.T) {
+	d1, err := ioutil.TempDir("", "old")
+	defer os.RemoveAll(d1)
+
+	d2, err := ioutil.TempDir("", "new")
+	defer os.RemoveAll(d2)
+	require.Nil(t, ioutil.WriteFile(filepath.Join(d1, "hello.txt"), []byte("hello"), 0644))
+
+	require.Nil(t, migrateDataDir(log.NewNopLogger(), d1, d2))
+
+	f, err := os.Stat(filepath.Join(d1, "hello.txt"))
+	require.NotNil(t, err, "old file should have moved: %#v", f)
+
+	_, err = os.Stat(filepath.Join(d2, "hello.txt"))
+	require.Nil(t, err, "new file should be there")
+
+	ok, err := dirExists(d1)
+	require.Nil(t, err)
+	require.False(t, ok, "old directory must be gone")
+}

--- a/misc/manifest.xml
+++ b/misc/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.Azure.Extensions</ProviderNameSpace>
   <Type>CustomScript</Type>
-  <Version>2.0.0</Version>
+  <Version>2.0.1</Version>
   <Label>Microsoft Azure Custom Script Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
Adding code to migrate /var/lib/azure/custom-script to
/var/lib/waagent/custom-script so that it gets cleaned up on
'waagent -deprovision' path. Shelling out to `mv -f` for recursive
file copying.

Also bumped version to v2.0.1.

cc: @boumenot