### PR TITLE
Do not overwrite .status file in new enables

### DIFF
--- a/integration-test/test/handler-commands.bats
+++ b/integration-test/test/handler-commands.bats
@@ -169,6 +169,18 @@ teardown(){
     [[ "$existing" == "$got" ]]
 }
 
+
+@test "handler command: enable - forking into background does not overwrite existing status" {
+    mk_container sh -c "fake-waagent install && fake-waagent enable && wait-for-enable && fake-waagent enable && wait-for-enable"
+    push_settings '{"commandToExecute": "date"}' ''
+    run start_container
+    echo "$output"
+
+    # validate .status file still reads "Enable succeeded"
+    status_file="$(container_read_file /var/lib/waagent/Extension/status/0.status)"
+    echo "$status_file"; [[ "$status_file" = *'Enable succeeded'* ]]
+}
+
 @test "handler command: uninstall - deletes the data dir" {
     run in_container sh -c \
         "fake-waagent install && fake-waagent uninstall"

--- a/main/main.go
+++ b/main/main.go
@@ -46,8 +46,16 @@ func main() {
 	}
 	ctx = ctx.With("seq", seqNum)
 
-	// execute the subcommand
+	// check sub-command preconditions, if any, before executing
 	ctx.Log("event", "start")
+	if cmd.pre != nil {
+		ctx.Log("event", "pre-check")
+		if err := cmd.pre(ctx, seqNum); err != nil {
+			ctx.Log("event", "pre-check failed", "error", err)
+			os.Exit(1)
+		}
+	}
+	// execute the subcommand
 	reportStatus(ctx, hEnv, seqNum, status.StatusTransitioning, cmd, "")
 	if err := cmd.f(ctx, hEnv, seqNum); err != nil {
 		ctx.Log("event", "failed to handle", "error", err)

--- a/misc/custom-script-shim
+++ b/misc/custom-script-shim
@@ -25,25 +25,29 @@ status_file_path() {
 }
 
 write_status() {
-	timestamp="$(date --utc --iso-8601=seconds)"
 	status_file="$(status_file_path)"
-	echo "Writing status to $status_file."
-	cat > "$status_file" <<- EOF
-		[
-			{
-				"version": 1,
-				"timestampUTC": "$timestamp",
-				"status": {
-					"operation": "Enable",
-					"status": "transitioning",
-					"formattedMessage": {
-						"lang": "en",
-						"message": "Enable in progress"
+	if [ -f "$status_file" ]; then
+		echo "Not writing a placeholder status file, already exists: $status_file"
+	else
+		echo "Writing a placeholder status file indicating progress before forking: $status_file"
+		timestamp="$(date --utc --iso-8601=seconds)"
+		cat > "$status_file" <<- EOF
+			[
+				{
+					"version": 1,
+					"timestampUTC": "$timestamp",
+					"status": {
+						"operation": "Enable",
+						"status": "transitioning",
+						"formattedMessage": {
+							"lang": "en",
+							"message": "Enable in progress"
+						}
 					}
 				}
-			}
-		]
-	EOF
+			]
+		EOF
+	fi
 }
 
 if [ "$#" -ne 1 ]; then


### PR DESCRIPTION
Updating custom-script-shim to not to overwrite a placeholder
"transitioning" `.status` file if it already exists.

Updating handler code writing "transitioning" `.status` file to
not to write the `.status` file until the sequence number check
is completed in the "enable" cmd.

Added integration tests to validate this case.

cc: @boumenot