### PR TITLE
fix tests with new storage account name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 before_script:
   - docker version
   - docker info
-  - azure -v
+  - azure telemetry --disable && azure -v
 script:
   - test -z "$(gofmt -s -l -w $(find . -type f -name '*.go' -not -path './vendor/*') | tee /dev/stderr)"
   - test -z "$(golint . | tee /dev/stderr)"

--- a/pkg/download/blob_test.go
+++ b/pkg/download/blob_test.go
@@ -64,7 +64,7 @@ func Test_blobDownload_getURL(t *testing.T) {
 }
 
 func Test_blobDownload_fails_badCreds(t *testing.T) {
-	d := NewBlobDownload("accountname", "Zm9vCg==", blobutil.AzureBlobRef{
+	d := NewBlobDownload("example", "Zm9vCg==", blobutil.AzureBlobRef{
 		StorageBase: storage.DefaultBaseURL,
 		Blob:        "fooBlob.txt",
 		Container:   "foocontainer",


### PR DESCRIPTION
The storage tests started to get "no such error" instead of HTTP 403
because the owner of 'accountname' account deleted the account. So
changing it to 'example' for the time being.

Also disabling CLI telemetry prompt, saves 30s in tests.