### PR TITLE
Tail stdout/stderr files in enable status message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: true
 services:
  - docker
 language: go
-go: go1.6
+go: go1.7
 install:
   - sudo add-apt-repository ppa:duggan/bats --yes
   - sudo apt-get update -qq

--- a/integration-test/test/handler-commands.bats
+++ b/integration-test/test/handler-commands.bats
@@ -45,8 +45,7 @@ teardown(){
     [[ "$output" == *"json validation error: invalid public settings JSON: badElement"* ]]
 }
 
-
-@test "handler command: enable - captures stdout/stderr into file" {
+@test "handler command: enable - captures stdout/stderr into file and .status" {
     mk_container sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
     push_settings '
     {
@@ -60,6 +59,9 @@ teardown(){
     echo "stdout=$stdout" && [[ "$stdout" = "HelloStdout" ]]
     stderr="$(container_read_file /var/lib/waagent/custom-script/download/0/stderr)"
     echo "stderr=$stderr" && [[ "$stderr" = "HelloStderr" ]]
+
+    status_file="$(container_read_file /var/lib/waagent/Extension/status/0.status)"
+    echo "status_file=$status_file"; [[ "$status_file" = *'Enable succeeded: \n[stdout]\nHelloStdout\n\n[stderr]\nHelloStderr\n'* ]]
 }
 
 @test "handler command: enable - doesn't process the same sequence number again" {

--- a/main/exec.go
+++ b/main/exec.go
@@ -43,8 +43,7 @@ func Exec(cmd, workdir string, stdout, stderr io.WriteCloser) (int, error) {
 // Ideally, we execute commands only once per sequence number in custom-script-extension,
 // and save their output under /var/lib/waagent/<dir>/download/<seqnum>/*.
 func ExecCmdInDir(cmd, workdir string) error {
-	outFn := filepath.Join(workdir, "stdout")
-	errFn := filepath.Join(workdir, "stderr")
+	outFn, errFn := logPaths(workdir)
 
 	outF, err := os.OpenFile(outFn, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 	if err != nil {
@@ -57,4 +56,10 @@ func ExecCmdInDir(cmd, workdir string) error {
 
 	_, err = Exec(cmd, workdir, outF, errF)
 	return err
+}
+
+// logPaths returns stdout and stderr file paths for the specified output
+// directory. It does not create the files.
+func logPaths(dir string) (stdout string, stderr string) {
+	return filepath.Join(dir, "stdout"), filepath.Join(dir, "stderr")
 }

--- a/main/exec_test.go
+++ b/main/exec_test.go
@@ -107,6 +107,12 @@ func TestExecCmdInDir_truncates(t *testing.T) {
 	require.Equal(t, "2:err\n", string(b), "stderr did not truncate")
 }
 
+func Test_logPaths(t *testing.T) {
+	stdout, stderr := logPaths("/tmp")
+	require.Equal(t, "/tmp/stdout", stdout)
+	require.Equal(t, "/tmp/stderr", stderr)
+}
+
 // Test utilities
 
 type mockFile struct {

--- a/main/logtail.go
+++ b/main/logtail.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// tailFile returns the last max bytes (or the entire file if the file size is
+// smaller than max) from the file at path. If the file does not exist, it
+// returns a nil slice and no error.
+func tailFile(path string, max int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil && os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Wrap(err, "error opening file")
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, errors.Wrap(err, "error retrieving file info")
+	}
+	size := fi.Size()
+
+	n := max
+	if size < n {
+		n = size
+	}
+	_, err = f.Seek(-n, io.SeekEnd)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error seeking file: offset=%d whence=%v", n, io.SeekEnd)
+	}
+
+	b, err := ioutil.ReadAll(io.LimitReader(f, max))
+	return b, errors.Wrap(err, "error reading from file")
+}

--- a/main/logtail_test.go
+++ b/main/logtail_test.go
@@ -1,13 +1,10 @@
 package main
 
 import (
-	"testing"
-
-	"io/ioutil"
-
-	"os"
-
 	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
 
 	"github.com/stretchr/testify/require"
 )

--- a/main/logtail_test.go
+++ b/main/logtail_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+
+	"io/ioutil"
+
+	"os"
+
+	"bytes"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_tailFile_notFound(t *testing.T) {
+	b, err := tailFile("/non/existing/path", 1024)
+	require.Nil(t, err)
+	require.Len(t, b, 0)
+}
+
+func Test_tailFile_openError(t *testing.T) {
+	tf := tempFile(t)
+	defer os.RemoveAll(tf)
+
+	require.Nil(t, os.Chmod(tf, 0333)) // no read
+	_, err := tailFile(tf, 1024)
+	require.NotNil(t, err)
+	require.Regexp(t, `^error opening file:`, err.Error())
+}
+
+func Test_tailFile(t *testing.T) {
+	tf := tempFile(t)
+	defer os.RemoveAll(tf)
+
+	in := bytes.Repeat([]byte("0123456789"), 10)
+	require.Nil(t, ioutil.WriteFile(tf, in, 0666))
+
+	// max=0
+	b, err := tailFile(tf, 0)
+	require.Nil(t, err)
+	require.Len(t, b, 0)
+
+	// max < size
+	b, err = tailFile(tf, 5)
+	require.Nil(t, err)
+	require.EqualValues(t, []byte("56789"), b)
+
+	// max==size
+	b, err = tailFile(tf, int64(len(in)))
+	require.Nil(t, err)
+	require.EqualValues(t, in, b)
+
+	// max>=size
+	b, err = tailFile(tf, int64(len(in)+1000))
+	require.Nil(t, err)
+	require.EqualValues(t, in, b)
+}
+
+func tempFile(t *testing.T) string {
+	f, err := ioutil.TempFile("", "")
+	require.Nil(t, err, "error creating test file")
+	defer f.Close()
+	return f.Name()
+}

--- a/main/main.go
+++ b/main/main.go
@@ -57,12 +57,13 @@ func main() {
 	}
 	// execute the subcommand
 	reportStatus(ctx, hEnv, seqNum, status.StatusTransitioning, cmd, "")
-	if err := cmd.f(ctx, hEnv, seqNum); err != nil {
+	msg, err := cmd.f(ctx, hEnv, seqNum)
+	if err != nil {
 		ctx.Log("event", "failed to handle", "error", err)
 		reportStatus(ctx, hEnv, seqNum, status.StatusError, cmd, err.Error())
 		os.Exit(1)
 	}
-	reportStatus(ctx, hEnv, seqNum, status.StatusSuccess, cmd, "")
+	reportStatus(ctx, hEnv, seqNum, status.StatusSuccess, cmd, msg)
 	ctx.Log("event", "end")
 }
 


### PR DESCRIPTION
See #67 for more info.

This change adds executed tail (max: 4k) of the executed script's stderr/stdout into the status message delivered via `.status` file. A new status file is in the format of:

    Enable (succeeded|failed): \n[stdout]\n(..bytes..)\n[stderr]\n(..bytes..)

And it looks like this in practice where `"commandToExecute": "echo HelloStdout>&1; echo HelloStderr>&2"`:

```json
[
  {
    "version": 1,
    "timestampUTC": "2016-11-28T23:41:31Z",
    "status": {
      "operation": "Enable",
      "status": "success",
      "formattedMessage": {
        "lang": "en",
        "message": "Enable succeeded: \n[stdout]\nHelloStdout\n\n[stderr]\nHelloStderr\n"
      }
    }
  }
]
```

cc: @boumenot 