### PR TITLE
Auto create dataDir on preEnable

### DIFF
--- a/misc/HandlerManifest.json
+++ b/misc/HandlerManifest.json
@@ -8,6 +8,6 @@
     "disableCommand": "bin/custom-script-shim disable",
     "rebootAfterInstall": false,
     "reportHeartbeat": false,
-    "updateMode": "UpdateWithoutInstall"
+    "updateMode": "UpdateWithInstall"
   }
 }]


### PR DESCRIPTION
The extension should be executing install upon upgrade.  The uninstall operation deletes the scratch directory, and install must run to re-create that directory.

Closes #114