### PR TITLE
Find bash from env

### DIFF
--- a/misc/custom-script-shim
+++ b/misc/custom-script-shim
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 readonly SCRIPT_DIR=$(dirname "$0")


### PR DESCRIPTION
So that custom-script-shim works on distros where bash is not in /bin