### PR TITLE
RBAC support for downloading scripts with managed identities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - sudo npm install -g azure-cli
   - go get -u golang.org/x/lint/golint
   - go get -u github.com/ahmetalpbalkan/govvv
+  - go get -u -d github.com/Azure/azure-extension-foundation/...
 before_script:
   - docker version
   - docker info

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ binary: clean
 	  echo "GOPATH is not set"; \
 	  exit 1; \
 	fi
-	go get -d github.com/Azure/azure-extension-foundation/...
+	go get -d -u -f github.com/Azure/azure-extension-foundation/...
 	GOOS=linux GOARCH=amd64 govvv build -v \
 	  -ldflags "-X main.Version=`grep -E -m 1 -o  '<Version>(.*)</Version>' misc/manifest.xml | awk -F">" '{print $$2}' | awk -F"<" '{print $$1}'`" \
 	  -o $(BINDIR)/$(BIN) ./main 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ binary: clean
 	  echo "GOPATH is not set"; \
 	  exit 1; \
 	fi
+	go get -d github.com/Azure/azure-extension-foundation/...
 	GOOS=linux GOARCH=amd64 govvv build -v \
 	  -ldflags "-X main.Version=`grep -E -m 1 -o  '<Version>(.*)</Version>' misc/manifest.xml | awk -F">" '{print $$2}' | awk -F"<" '{print $$1}'`" \
 	  -o $(BINDIR)/$(BIN) ./main 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ RedHat RHEL 6.9|![badge](https://dcrbadges.blob.core.windows.net/scenarios/RedHa
 RedHat RHEL 7-RAW|![badge](https://dcrbadges.blob.core.windows.net/scenarios/RedHat_RHEL_7-RAW__ext--custom--script.svg)
 SUSE SLES 12-SP2|![badge](https://dcrbadges.blob.core.windows.net/scenarios/SUSE_SLES_12-SP2__ext--custom--script.svg)
 
-This documentation is current for version 2.0.6 and above.
+This documentation is current for version 2.0.8 and above.
 
 CustomScript extensions runs scripts on VMs.  These scripts can be
 used to bootstrap/install software, run administrative tasks, or run

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ RedHat RHEL 6.9|![badge](https://dcrbadges.blob.core.windows.net/scenarios/RedHa
 RedHat RHEL 7-RAW|![badge](https://dcrbadges.blob.core.windows.net/scenarios/RedHat_RHEL_7-RAW__ext--custom--script.svg)
 SUSE SLES 12-SP2|![badge](https://dcrbadges.blob.core.windows.net/scenarios/SUSE_SLES_12-SP2__ext--custom--script.svg)
 
-This documentation is current for version 2.0.8 and above.
+This documentation is current for version 2.0.6 and above.
 
 CustomScript extensions runs scripts on VMs.  These scripts can be
 used to bootstrap/install software, run administrative tasks, or run

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -230,7 +230,7 @@ func downloadFiles(ctx *log.Context, dir string, cfg handlerSettings) error {
 	for i, f := range cfg.fileUrls() {
 		ctx := ctx.With("file", i)
 		ctx.Log("event", "download start")
-		if err := downloadAndProcessURL(ctx, f, dir, cfg.StorageAccountName, cfg.StorageAccountKey, cfg.publicSettings.SkipDos2Unix); err != nil {
+		if err := downloadAndProcessURL(ctx, f, dir, &cfg); err != nil {
 			ctx.Log("event", "download failed", "error", err)
 			return errors.Wrapf(err, "failed to download file[%d]", i)
 		}

--- a/main/files.go
+++ b/main/files.go
@@ -60,11 +60,11 @@ func getDownloaders(fileURL string, storageAccountName, storageAccountKey string
 			switch {
 			case managedIdentity.ClientId == "" && managedIdentity.ObjectId == "":
 				// get msi using clientId or objectId or implicitly
-				msiProvider = download.GetMsiProviderForStorageAccountsImplicitly()
+				msiProvider = download.GetMsiProviderForStorageAccountsImplicitly(fileURL)
 			case managedIdentity.ClientId != "" && managedIdentity.ObjectId == "":
-				msiProvider = download.GetMsiProviderForStorageAccountsWithClientId(managedIdentity.ClientId)
+				msiProvider = download.GetMsiProviderForStorageAccountsWithClientId(fileURL, managedIdentity.ClientId)
 			case managedIdentity.ClientId == "" && managedIdentity.ObjectId != "":
-				msiProvider = download.GetMsiProviderForStorageAccountsWithObjectId(managedIdentity.ObjectId)
+				msiProvider = download.GetMsiProviderForStorageAccountsWithObjectId(fileURL, managedIdentity.ObjectId)
 			default:
 				return nil, fmt.Errorf("unexpected combination of ClientId and ObjectId found")
 			}

--- a/main/files.go
+++ b/main/files.go
@@ -60,9 +60,11 @@ func getDownloaders(fileURL string, storageAccountName, storageAccountKey string
 	[]download.Downloader, error) {
 	if storageAccountName == "" || storageAccountKey == "" {
 		if download.IsAzureStorageBlobUri(fileURL) {
-			msiProvider :=  msi.NewMsiProvider(httputil.NewSecureHttpClient(httputil.DefaultRetryBehavior))
-			return []download.Downloader{download.NewURLDownload(fileURL),
-			download.NewBlobWithMsiDownload(fileURL, &msiProvider )}, nil
+			msiProvider := msi.NewMsiProvider(httputil.NewSecureHttpClient(httputil.DefaultRetryBehavior))
+			return []download.Downloader{
+				download.NewURLDownload(fileURL),
+				download.NewBlobWithMsiDownload(fileURL, &msiProvider),
+			}, nil
 		} else {
 			return []download.Downloader{download.NewURLDownload(fileURL)}, nil
 		}

--- a/main/files_test.go
+++ b/main/files_test.go
@@ -31,6 +31,13 @@ func Test_getDownloader_externalUrl(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, d)
 	require.NotEmpty(t, d)
+	require.Equal(t, 1, len(d))
+	require.Equal(t, "download.urlDownload", fmt.Sprintf("%T", d[0]), "got wrong type")
+
+	d, err = getDownloaders("http://acct.blob.core.windows.net/", "", "", &clientOrObjectId{"", "dummyclientid"})
+	require.Nil(t, err)
+	require.NotNil(t, d)
+	require.NotEmpty(t, d)
 	require.Equal(t, 2, len(d))
 	require.Equal(t, "download.urlDownload", fmt.Sprintf("%T", d[0]), "got wrong type")
 	require.Equal(t, "*download.blobWithMsiToken", fmt.Sprintf("%T", d[1]), "got wrong type")
@@ -38,16 +45,14 @@ func Test_getDownloader_externalUrl(t *testing.T) {
 	d, err = getDownloaders("http://acct.blob.core.windows.net/", "foo", "", nil)
 	require.Nil(t, err)
 	require.NotNil(t, d)
-	require.Equal(t, 2, len(d))
+	require.Equal(t, 1, len(d))
 	require.Equal(t, "download.urlDownload", fmt.Sprintf("%T", d[0]), "got wrong type")
-	require.Equal(t, "*download.blobWithMsiToken", fmt.Sprintf("%T", d[1]), "got wrong type")
 
 	d, err = getDownloaders("http://acct.blob.core.windows.net/", "", "bar", nil)
 	require.Nil(t, err)
 	require.NotNil(t, d)
-	require.Equal(t, 2, len(d))
+	require.Equal(t, 1, len(d))
 	require.Equal(t, "download.urlDownload", fmt.Sprintf("%T", d[0]), "got wrong type")
-	require.Equal(t, "*download.blobWithMsiToken", fmt.Sprintf("%T", d[1]), "got wrong type")
 }
 
 func Test_urlToFileName_badURL(t *testing.T) {

--- a/main/files_test.go
+++ b/main/files_test.go
@@ -15,11 +15,11 @@ import (
 
 func Test_getDownloader_azureBlob(t *testing.T) {
 	// error condition
-	_, err := getDownloaders("http://acct.blob.core.windows.net/", "acct", "key")
+	_, err := getDownloaders("http://acct.blob.core.windows.net/", "acct", "key", nil)
 	require.NotNil(t, err)
 
 	// valid input
-	d, err := getDownloaders("http://acct.blob.core.windows.net/container/blob", "acct", "key")
+	d, err := getDownloaders("http://acct.blob.core.windows.net/container/blob", "acct", "key", nil)
 	require.Nil(t, err)
 	require.NotNil(t, d)
 	require.Equal(t, 1, len(d))
@@ -27,7 +27,7 @@ func Test_getDownloader_azureBlob(t *testing.T) {
 }
 
 func Test_getDownloader_externalUrl(t *testing.T) {
-	d, err := getDownloaders("http://acct.blob.core.windows.net/", "", "")
+	d, err := getDownloaders("http://acct.blob.core.windows.net/", "", "", nil)
 	require.Nil(t, err)
 	require.NotNil(t, d)
 	require.NotEmpty(t, d)
@@ -35,14 +35,14 @@ func Test_getDownloader_externalUrl(t *testing.T) {
 	require.Equal(t, "download.urlDownload", fmt.Sprintf("%T", d[0]), "got wrong type")
 	require.Equal(t, "*download.blobWithMsiToken", fmt.Sprintf("%T", d[1]), "got wrong type")
 
-	d, err = getDownloaders("http://acct.blob.core.windows.net/", "foo", "")
+	d, err = getDownloaders("http://acct.blob.core.windows.net/", "foo", "", nil)
 	require.Nil(t, err)
 	require.NotNil(t, d)
 	require.Equal(t, 2, len(d))
 	require.Equal(t, "download.urlDownload", fmt.Sprintf("%T", d[0]), "got wrong type")
 	require.Equal(t, "*download.blobWithMsiToken", fmt.Sprintf("%T", d[1]), "got wrong type")
 
-	d, err = getDownloaders("http://acct.blob.core.windows.net/", "", "bar")
+	d, err = getDownloaders("http://acct.blob.core.windows.net/", "", "bar", nil)
 	require.Nil(t, err)
 	require.NotNil(t, d)
 	require.Equal(t, 2, len(d))

--- a/main/files_test.go
+++ b/main/files_test.go
@@ -110,7 +110,8 @@ func Test_downloadAndProcessURL(t *testing.T) {
 	require.Nil(t, err)
 	defer os.RemoveAll(tmpDir)
 
-	err = downloadAndProcessURL(log.NewContext(log.NewNopLogger()), srv.URL+"/bytes/256", tmpDir, "", "", false)
+	cfg := handlerSettings{publicSettings{}, protectedSettings{StorageAccountName: "", StorageAccountKey: ""}}
+	err = downloadAndProcessURL(log.NewContext(log.NewNopLogger()), srv.URL+"/bytes/256", tmpDir, &cfg)
 	require.Nil(t, err)
 
 	fp := filepath.Join(tmpDir, "256")

--- a/main/files_test.go
+++ b/main/files_test.go
@@ -15,31 +15,39 @@ import (
 
 func Test_getDownloader_azureBlob(t *testing.T) {
 	// error condition
-	_, err := getDownloader("http://acct.blob.core.windows.net/", "acct", "key")
+	_, err := getDownloaders("http://acct.blob.core.windows.net/", "acct", "key")
 	require.NotNil(t, err)
 
 	// valid input
-	d, err := getDownloader("http://acct.blob.core.windows.net/container/blob", "acct", "key")
+	d, err := getDownloaders("http://acct.blob.core.windows.net/container/blob", "acct", "key")
 	require.Nil(t, err)
 	require.NotNil(t, d)
-	require.Equal(t, "download.blobDownload", fmt.Sprintf("%T", d), "got wrong type")
+	require.Equal(t, 1, len(d))
+	require.Equal(t, "download.blobDownload", fmt.Sprintf("%T", d[0]), "got wrong type")
 }
 
 func Test_getDownloader_externalUrl(t *testing.T) {
-	d, err := getDownloader("http://acct.blob.core.windows.net/", "", "")
+	d, err := getDownloaders("http://acct.blob.core.windows.net/", "", "")
 	require.Nil(t, err)
 	require.NotNil(t, d)
-	require.Equal(t, "download.urlDownload", fmt.Sprintf("%T", d), "got wrong type")
+	require.NotEmpty(t, d)
+	require.Equal(t, 2, len(d))
+	require.Equal(t, "download.urlDownload", fmt.Sprintf("%T", d[0]), "got wrong type")
+	require.Equal(t, "*download.blobWithMsiToken", fmt.Sprintf("%T", d[1]), "got wrong type")
 
-	d, err = getDownloader("http://acct.blob.core.windows.net/", "foo", "")
+	d, err = getDownloaders("http://acct.blob.core.windows.net/", "foo", "")
 	require.Nil(t, err)
 	require.NotNil(t, d)
-	require.Equal(t, "download.urlDownload", fmt.Sprintf("%T", d), "got wrong type")
+	require.Equal(t, 2, len(d))
+	require.Equal(t, "download.urlDownload", fmt.Sprintf("%T", d[0]), "got wrong type")
+	require.Equal(t, "*download.blobWithMsiToken", fmt.Sprintf("%T", d[1]), "got wrong type")
 
-	d, err = getDownloader("http://acct.blob.core.windows.net/", "", "bar")
+	d, err = getDownloaders("http://acct.blob.core.windows.net/", "", "bar")
 	require.Nil(t, err)
 	require.NotNil(t, d)
-	require.Equal(t, "download.urlDownload", fmt.Sprintf("%T", d), "got wrong type")
+	require.Equal(t, 2, len(d))
+	require.Equal(t, "download.urlDownload", fmt.Sprintf("%T", d[0]), "got wrong type")
+	require.Equal(t, "*download.blobWithMsiToken", fmt.Sprintf("%T", d[1]), "got wrong type")
 }
 
 func Test_urlToFileName_badURL(t *testing.T) {

--- a/main/handlersettings.go
+++ b/main/handlersettings.go
@@ -91,11 +91,11 @@ type publicSettings struct {
 // protectedSettings is the type decoded and deserialized from protected
 // configuration section. This should be in sync with protectedSettingsSchema.
 type protectedSettings struct {
-	CommandToExecute       string           `json:"commandToExecute"`
-	Script                 string           `json:"script"`
-	FileURLs               []string         `json:"fileUris"`
-	StorageAccountName     string           `json:"storageAccountName"`
-	StorageAccountKey      string           `json:"storageAccountKey"`
+	CommandToExecute       string            `json:"commandToExecute"`
+	Script                 string            `json:"script"`
+	FileURLs               []string          `json:"fileUris"`
+	StorageAccountName     string            `json:"storageAccountName"`
+	StorageAccountKey      string            `json:"storageAccountKey"`
 	ManagedServiceIdentity *clientOrObjectId `json:managedServiceIdentity`
 }
 

--- a/main/handlersettings.go
+++ b/main/handlersettings.go
@@ -73,7 +73,7 @@ func (h handlerSettings) validate() error {
 	}
 
 	if h.protectedSettings.ManagedServiceIdentity.ClientId != "" && h.protectedSettings.ManagedServiceIdentity.ObjectId != "" {
-
+		return errUsingBothClientIdAndObjectId
 	}
 
 	return nil

--- a/main/handlersettings.go
+++ b/main/handlersettings.go
@@ -68,7 +68,7 @@ func (h handlerSettings) validate() error {
 		return errStoragePartialCredentials
 	}
 
-	if (h.protectedSettings.StorageAccountKey != "" || h.protectedSettings.StorageAccountName != "") && !h.protectedSettings.ManagedIdentity.isEmpty() {
+	if (h.protectedSettings.StorageAccountKey != "" || h.protectedSettings.StorageAccountName != "") && h.protectedSettings.ManagedIdentity != nil {
 		return errUsingBothKeyAndMsi
 	}
 

--- a/main/handlersettings.go
+++ b/main/handlersettings.go
@@ -68,12 +68,14 @@ func (h handlerSettings) validate() error {
 		return errStoragePartialCredentials
 	}
 
-	if (h.protectedSettings.StorageAccountKey != "" || h.protectedSettings.StorageAccountName != "") && !h.protectedSettings.ManagedServiceIdentity.isEmpty() {
+	if (h.protectedSettings.StorageAccountKey != "" || h.protectedSettings.StorageAccountName != "") && !h.protectedSettings.ManagedIdentity.isEmpty() {
 		return errUsingBothKeyAndMsi
 	}
 
-	if h.protectedSettings.ManagedServiceIdentity.ClientId != "" && h.protectedSettings.ManagedServiceIdentity.ObjectId != "" {
-		return errUsingBothClientIdAndObjectId
+	if h.protectedSettings.ManagedIdentity != nil {
+		if h.protectedSettings.ManagedIdentity.ClientId != "" && h.protectedSettings.ManagedIdentity.ObjectId != "" {
+			return errUsingBothClientIdAndObjectId
+		}
 	}
 
 	return nil
@@ -91,12 +93,12 @@ type publicSettings struct {
 // protectedSettings is the type decoded and deserialized from protected
 // configuration section. This should be in sync with protectedSettingsSchema.
 type protectedSettings struct {
-	CommandToExecute       string            `json:"commandToExecute"`
-	Script                 string            `json:"script"`
-	FileURLs               []string          `json:"fileUris"`
-	StorageAccountName     string            `json:"storageAccountName"`
-	StorageAccountKey      string            `json:"storageAccountKey"`
-	ManagedServiceIdentity *clientOrObjectId `json:managedServiceIdentity`
+	CommandToExecute   string            `json:"commandToExecute"`
+	Script             string            `json:"script"`
+	FileURLs           []string          `json:"fileUris"`
+	StorageAccountName string            `json:"storageAccountName"`
+	StorageAccountKey  string            `json:"storageAccountKey"`
+	ManagedIdentity    *clientOrObjectId `json:"managedIdentity"`
 }
 
 type clientOrObjectId struct {

--- a/main/handlersettings.go
+++ b/main/handlersettings.go
@@ -96,7 +96,7 @@ type protectedSettings struct {
 	FileURLs               []string         `json:"fileUris"`
 	StorageAccountName     string           `json:"storageAccountName"`
 	StorageAccountKey      string           `json:"storageAccountKey"`
-	ManagedServiceIdentity clientOrObjectId `json:managedServiceIdentity`
+	ManagedServiceIdentity *clientOrObjectId `json:managedServiceIdentity`
 }
 
 type clientOrObjectId struct {

--- a/main/handlersettings_test.go
+++ b/main/handlersettings_test.go
@@ -86,6 +86,32 @@ func Test_skipDos2UnixDefaultsToFalse(t *testing.T) {
 	require.Equal(t, false, testSubject.SkipDos2Unix)
 }
 
+func Test_managedSystemIdentityVerification(t *testing.T) {
+	require.NoError(t, handlerSettings{publicSettings{}, protectedSettings{
+		CommandToExecute: "echo hi",
+		FileURLs:         []string{"file1", "file2"},
+		ManagedServiceIdentity: clientOrObjectId{
+			ClientId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
+		},
+	}}.validate(), "validation failed for settings with MSI")
+
+	require.NoError(t, handlerSettings{publicSettings{}, protectedSettings{
+		CommandToExecute: "echo hi",
+		ManagedServiceIdentity: clientOrObjectId{
+			ObjectId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
+		},
+	}}.validate(), "validation failed for settings with MSI")
+
+	require.Error(t, handlerSettings{publicSettings{}, protectedSettings{
+		CommandToExecute:   "echo hi",
+		StorageAccountName: "name",
+		StorageAccountKey:  "key",
+		ManagedServiceIdentity: clientOrObjectId{
+			ObjectId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
+		},
+	}}.validate(), "validation didn't fail for settings with both MSI and storage account")
+}
+
 func Test_toJSON_empty(t *testing.T) {
 	s, err := toJSON(nil)
 	require.Nil(t, err)

--- a/main/handlersettings_test.go
+++ b/main/handlersettings_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 import "github.com/stretchr/testify/require"
 
 func Test_handlerSettingsValidate(t *testing.T) {
@@ -86,18 +89,18 @@ func Test_skipDos2UnixDefaultsToFalse(t *testing.T) {
 	require.Equal(t, false, testSubject.SkipDos2Unix)
 }
 
-func Test_managedSystemIdentityVerification(t *testing.T) {
+func Test_managedIdentityVerification(t *testing.T) {
 	require.NoError(t, handlerSettings{publicSettings{}, protectedSettings{
 		CommandToExecute: "echo hi",
 		FileURLs:         []string{"file1", "file2"},
-		ManagedServiceIdentity: &clientOrObjectId{
+		ManagedIdentity: &clientOrObjectId{
 			ClientId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
 		},
 	}}.validate(), "validation failed for settings with MSI")
 
 	require.NoError(t, handlerSettings{publicSettings{}, protectedSettings{
 		CommandToExecute: "echo hi",
-		ManagedServiceIdentity: &clientOrObjectId{
+		ManagedIdentity: &clientOrObjectId{
 			ObjectId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
 		},
 	}}.validate(), "validation failed for settings with MSI")
@@ -108,7 +111,7 @@ func Test_managedSystemIdentityVerification(t *testing.T) {
 				CommandToExecute:   "echo hi",
 				StorageAccountName: "name",
 				StorageAccountKey:  "key",
-				ManagedServiceIdentity: &clientOrObjectId{
+				ManagedIdentity: &clientOrObjectId{
 					ObjectId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
 				},
 			}}.validate(), "validation didn't fail for settings with both MSI and storage account")
@@ -117,7 +120,7 @@ func Test_managedSystemIdentityVerification(t *testing.T) {
 		handlerSettings{publicSettings{},
 			protectedSettings{
 				CommandToExecute: "echo hi",
-				ManagedServiceIdentity: &clientOrObjectId{
+				ManagedIdentity: &clientOrObjectId{
 					ObjectId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
 					ClientId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
 				},
@@ -135,4 +138,59 @@ func Test_toJSON(t *testing.T) {
 		"a": 3})
 	require.Nil(t, err)
 	require.Equal(t, `{"a":3}`, s)
+}
+
+func Test_toJSONUmarshallForManagedIdentity(t *testing.T) {
+	testString := `{"commandToExecute" : "echo hello", "fileUris":["https://a.com/file.txt", "https://b.com/file2.txt"]}`
+	require.NoError(t, validateProtectedSettings(testString), "protected settings should be valid")
+	protSettings := new(protectedSettings)
+	err := json.Unmarshal([]byte(testString), protSettings)
+	require.NoError(t, err, "error while deserializing json")
+	require.Nil(t, protSettings.ManagedIdentity, "ProtectedSettings.ManagedIdentity was expected to be nil")
+	h := handlerSettings{publicSettings{}, *protSettings}
+	require.NoError(t, h.validate(), "settings should be valid")
+
+	testString = `{"commandToExecute" : "echo hello", "fileUris":["https://a.com/file.txt"], "managedIdentity": { }}`
+	require.NoError(t, validateProtectedSettings(testString), "protected settings should be valid")
+	protSettings = new(protectedSettings)
+	err = json.Unmarshal([]byte(testString), protSettings)
+	require.NoError(t, err, "error while deserializing json")
+	require.NotNil(t, protSettings.ManagedIdentity, "ProtectedSettings.ManagedIdentity was expected to not be nil")
+	require.Equal(t, protSettings.ManagedIdentity.ClientId, "")
+	require.Equal(t, protSettings.ManagedIdentity.ObjectId, "")
+	h = handlerSettings{publicSettings{}, *protSettings}
+	require.NoError(t, h.validate(), "settings should be valid")
+
+	testString = `{"commandToExecute" : "echo hello", "fileUris":["https://a.com/file.txt", "https://b.com/file2.txt"], "managedIdentity": { "clientId": "31b403aa-c364-4240-a7ff-d85fb6cd7232"}}`
+	require.NoError(t, validateProtectedSettings(testString), "protected settings should be valid")
+	protSettings = new(protectedSettings)
+	err = json.Unmarshal([]byte(testString), protSettings)
+	require.NoError(t, err, "error while deserializing json")
+	require.NotNil(t, protSettings.ManagedIdentity, "ProtectedSettings.ManagedIdentity was expected to not be nil")
+	require.Equal(t, protSettings.ManagedIdentity.ClientId, "31b403aa-c364-4240-a7ff-d85fb6cd7232")
+	require.Equal(t, protSettings.ManagedIdentity.ObjectId, "")
+	h = handlerSettings{publicSettings{}, *protSettings}
+	require.NoError(t, h.validate(), "settings should be valid")
+
+	testString = `{"commandToExecute" : "echo hello", "fileUris":["https://a.com/file.txt"], "managedIdentity": { "objectId": "31b403aa-c364-4240-a7ff-d85fb6cd7232"}}`
+	require.NoError(t, validateProtectedSettings(testString), "protected settings should be valid")
+	protSettings = new(protectedSettings)
+	err = json.Unmarshal([]byte(testString), protSettings)
+	require.NoError(t, err, "error while deserializing json")
+	require.NotNil(t, protSettings.ManagedIdentity, "ProtectedSettings.ManagedIdentity was expected to not be nil")
+	require.Equal(t, protSettings.ManagedIdentity.ObjectId, "31b403aa-c364-4240-a7ff-d85fb6cd7232")
+	require.Equal(t, protSettings.ManagedIdentity.ClientId, "")
+	h = handlerSettings{publicSettings{}, *protSettings}
+	require.NoError(t, h.validate(), "settings should be valid")
+
+	testString = `{"commandToExecute" : "echo hello", "fileUris":["https://a.com/file.txt", "https://b.com/file2.txt"], "managedIdentity": { "clientId": "31b403aa-c364-4240-a7ff-d85fb6cd7232", "objectId": "41b403aa-c364-4240-a7ff-d85fb6cd7232"}}`
+	require.NoError(t, validateProtectedSettings(testString), "protected settings should be valid")
+	protSettings = new(protectedSettings)
+	err = json.Unmarshal([]byte(testString), protSettings)
+	require.NoError(t, err, "error while deserializing json")
+	require.NotNil(t, protSettings.ManagedIdentity, "ProtectedSettings.ManagedIdentity was expected to not be nil")
+	require.Equal(t, protSettings.ManagedIdentity.ClientId, "31b403aa-c364-4240-a7ff-d85fb6cd7232")
+	require.Equal(t, protSettings.ManagedIdentity.ObjectId, "41b403aa-c364-4240-a7ff-d85fb6cd7232")
+	h = handlerSettings{publicSettings{}, *protSettings}
+	require.Error(t, h.validate(), "settings should be invalid")
 }

--- a/main/handlersettings_test.go
+++ b/main/handlersettings_test.go
@@ -116,7 +116,7 @@ func Test_managedSystemIdentityVerification(t *testing.T) {
 	require.Equal(t, errUsingBothClientIdAndObjectId,
 		handlerSettings{publicSettings{},
 			protectedSettings{
-				CommandToExecute:   "echo hi",
+				CommandToExecute: "echo hi",
 				ManagedServiceIdentity: &clientOrObjectId{
 					ObjectId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
 					ClientId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",

--- a/main/handlersettings_test.go
+++ b/main/handlersettings_test.go
@@ -90,14 +90,14 @@ func Test_managedSystemIdentityVerification(t *testing.T) {
 	require.NoError(t, handlerSettings{publicSettings{}, protectedSettings{
 		CommandToExecute: "echo hi",
 		FileURLs:         []string{"file1", "file2"},
-		ManagedServiceIdentity: clientOrObjectId{
+		ManagedServiceIdentity: &clientOrObjectId{
 			ClientId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
 		},
 	}}.validate(), "validation failed for settings with MSI")
 
 	require.NoError(t, handlerSettings{publicSettings{}, protectedSettings{
 		CommandToExecute: "echo hi",
-		ManagedServiceIdentity: clientOrObjectId{
+		ManagedServiceIdentity: &clientOrObjectId{
 			ObjectId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
 		},
 	}}.validate(), "validation failed for settings with MSI")
@@ -108,7 +108,7 @@ func Test_managedSystemIdentityVerification(t *testing.T) {
 				CommandToExecute:   "echo hi",
 				StorageAccountName: "name",
 				StorageAccountKey:  "key",
-				ManagedServiceIdentity: clientOrObjectId{
+				ManagedServiceIdentity: &clientOrObjectId{
 					ObjectId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
 				},
 			}}.validate(), "validation didn't fail for settings with both MSI and storage account")
@@ -117,7 +117,7 @@ func Test_managedSystemIdentityVerification(t *testing.T) {
 		handlerSettings{publicSettings{},
 			protectedSettings{
 				CommandToExecute:   "echo hi",
-				ManagedServiceIdentity: clientOrObjectId{
+				ManagedServiceIdentity: &clientOrObjectId{
 					ObjectId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
 					ClientId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
 				},

--- a/main/handlersettings_test.go
+++ b/main/handlersettings_test.go
@@ -102,14 +102,26 @@ func Test_managedSystemIdentityVerification(t *testing.T) {
 		},
 	}}.validate(), "validation failed for settings with MSI")
 
-	require.Error(t, handlerSettings{publicSettings{}, protectedSettings{
-		CommandToExecute:   "echo hi",
-		StorageAccountName: "name",
-		StorageAccountKey:  "key",
-		ManagedServiceIdentity: clientOrObjectId{
-			ObjectId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
-		},
-	}}.validate(), "validation didn't fail for settings with both MSI and storage account")
+	require.Equal(t, errUsingBothKeyAndMsi,
+		handlerSettings{publicSettings{},
+			protectedSettings{
+				CommandToExecute:   "echo hi",
+				StorageAccountName: "name",
+				StorageAccountKey:  "key",
+				ManagedServiceIdentity: clientOrObjectId{
+					ObjectId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
+				},
+			}}.validate(), "validation didn't fail for settings with both MSI and storage account")
+
+	require.Equal(t, errUsingBothClientIdAndObjectId,
+		handlerSettings{publicSettings{},
+			protectedSettings{
+				CommandToExecute:   "echo hi",
+				ManagedServiceIdentity: clientOrObjectId{
+					ObjectId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
+					ClientId: "31b403aa-c364-4240-a7ff-d85fb6cd7232",
+				},
+			}}.validate(), "validation didn't fail for settings with both MSI and storage account")
 }
 
 func Test_toJSON_empty(t *testing.T) {

--- a/main/schema.go
+++ b/main/schema.go
@@ -19,14 +19,14 @@ const (
       "description": "Command to be executed",
       "type": "string"
     },
-	"script": {
-	  "description": "Script to be executed",
-	  "type": "string"
-	},
-	"skipDos2Unix": {
-	  "description": "Skip DOS2UNIX and BOM removal for download files and script",
-	  "type": "boolean"
-	},
+    "script": {
+      "description": "Script to be executed",
+      "type": "string"
+    },
+    "skipDos2Unix": {
+      "description": "Skip DOS2UNIX and BOM removal for download files and script",
+      "type": "boolean"
+    },
     "fileUris": {
       "description": "List of files to be downloaded",
       "type": "array",
@@ -52,7 +52,7 @@ const (
       "description": "Command to be executed",
       "type": "string"
     },
-	"fileUris": {
+    "fileUris": {
       "description": "List of files to be downloaded",
       "type": "array",
       "items": {
@@ -60,10 +60,10 @@ const (
         "format": "uri"
       }
     },
-	"script": {
-	  "description": "Script to be executed",
-	  "type": "string"
-	},
+    "script": {
+      "description": "Script to be executed",
+      "type": "string"
+    },
     "storageAccountName": {
       "description": "Name of the Azure Storage Account (3-24 characters of lowercase letters or digits)",
       "type": "string",
@@ -74,22 +74,22 @@ const (
       "type": "string",
       "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$"
     },
-	"managedIdentity": {
+    "managedIdentity": {
       "description": "Setting to use Managed Service Identity to try to download fileUri from azure blob",
       "type": "object",
       "properties": {
         "objectId": {
           "description": "Object id that identifies the user created managed identity",
-		  "type": "string",
-		  "pattern": "^(?:[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12})$"
+          "type": "string",
+          "pattern": "^(?:[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12})$"
         },
         "clientId": {
           "description": "Client id that identifies the user created managed identity",
-		  "type": "string",
-	       "pattern": "^(?:[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12})$"
+          "type": "string",
+          "pattern": "^(?:[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12})$"
         }
       }
-	}
+    }
   },
   "additionalProperties": false
 }`

--- a/main/schema.go
+++ b/main/schema.go
@@ -74,7 +74,7 @@ const (
       "type": "string",
       "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$"
     },
-	"managedServiceIdentity": {
+	"managedIdentity": {
       "description": "Setting to use Managed Service Identity to try to download fileUri from azure blob",
       "type": "object",
       "properties": {

--- a/main/schema.go
+++ b/main/schema.go
@@ -73,7 +73,23 @@ const (
       "description": "Key for the Azure Storage Account (a base64 encoded string)",
       "type": "string",
       "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$"
-    }
+    },
+	"managedServiceIdentity": {
+      "description": "Setting to use Managed Service Identity to try to download fileUri from azure blob",
+      "type": "object",
+      "properties": {
+        "objectId": {
+          "description": "Object id that identifies the user created managed identity",
+		  "type": "string",
+		  "pattern": "^(?:[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12})$"
+        },
+        "clientId": {
+          "description": "Client id that identifies the user created managed identity",
+		  "type": "string",
+	       "pattern": "^(?:[0-9A-Fa-f]{8}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{4}[-][0-9A-Fa-f]{12})$"
+        }
+      }
+	}
   },
   "additionalProperties": false
 }`

--- a/main/schema_test.go
+++ b/main/schema_test.go
@@ -144,3 +144,15 @@ func TestValidateProtectedSettings_storageAccountKey(t *testing.T) {
 	require.Nil(t, validateProtectedSettings(`{"storageAccountKey": "A+hMRrsZQ6COPXTYX/EiKiF2HVtfhCfLDo3Dkc3ekKoX3jA58zXVG2QRe/C1+zdEFSrVX6FZsKyivsSlnwmWOw=="}`), "ok")
 	require.Nil(t, validateProtectedSettings(`{"storageAccountKey": "/yGnx6KyxQ8Pjzk0QXeY+66Du0BeTWaCt83la59w72hu/81e6TzskXXvL/IlO3q6g0k0kJrR9MYQNi+cNR3SXA=="}`), "ok")
 }
+
+func TestValidateProtectedSettings_managedServiceIdentity(t *testing.T) {
+	require.NoError(t, validateProtectedSettings(`{"managedServiceIdentity": { "clientId": "31b403aa-c364-4240-a7ff-d85fb6cd7232"}}`),
+		"couldn't parse msi proprety with lowercase guid")
+	require.NoError(t, validateProtectedSettings(`{"managedServiceIdentity": { "objectId": "31B403AA-C364-4240-A7FF-D85FB6CD7232"}}`),
+		"couldn't parse msi property with uppercase guid")
+	require.NoError(t, validateProtectedSettings(`{"managedServiceIdentity": { }}`),
+		"couldn't parse msi property without clientId or objectId")
+
+	require.Error(t, validateProtectedSettings(`{"managedServiceIdentity": { "clientId": "notaguid"}}`),
+		"guid validation succeded when expected to fail")
+}

--- a/main/schema_test.go
+++ b/main/schema_test.go
@@ -146,13 +146,13 @@ func TestValidateProtectedSettings_storageAccountKey(t *testing.T) {
 }
 
 func TestValidateProtectedSettings_managedServiceIdentity(t *testing.T) {
-	require.NoError(t, validateProtectedSettings(`{"managedServiceIdentity": { "clientId": "31b403aa-c364-4240-a7ff-d85fb6cd7232"}}`),
+	require.NoError(t, validateProtectedSettings(`{"managedIdentity": { "clientId": "31b403aa-c364-4240-a7ff-d85fb6cd7232"}}`),
 		"couldn't parse msi proprety with lowercase guid")
-	require.NoError(t, validateProtectedSettings(`{"managedServiceIdentity": { "objectId": "31B403AA-C364-4240-A7FF-D85FB6CD7232"}}`),
+	require.NoError(t, validateProtectedSettings(`{"managedIdentity": { "objectId": "31B403AA-C364-4240-A7FF-D85FB6CD7232"}}`),
 		"couldn't parse msi property with uppercase guid")
-	require.NoError(t, validateProtectedSettings(`{"managedServiceIdentity": { }}`),
+	require.NoError(t, validateProtectedSettings(`{"managedIdentity": { }}`),
 		"couldn't parse msi property without clientId or objectId")
 
-	require.Error(t, validateProtectedSettings(`{"managedServiceIdentity": { "clientId": "notaguid"}}`),
+	require.Error(t, validateProtectedSettings(`{"managedIdentity": { "clientId": "notaguid"}}`),
 		"guid validation succeded when expected to fail")
 }

--- a/misc/manifest.xml
+++ b/misc/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.Azure.Extensions</ProviderNameSpace>
   <Type>CustomScript</Type>
-  <Version>2.1.0</Version>
+  <Version>2.0.8</Version>
   <Label>Microsoft Azure Custom Script Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/misc/manifest.xml
+++ b/misc/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.Azure.Extensions</ProviderNameSpace>
   <Type>CustomScript</Type>
-  <Version>2.0.7</Version>
+  <Version>2.0.8</Version>
   <Label>Microsoft Azure Custom Script Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/misc/manifest.xml
+++ b/misc/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.Azure.Extensions</ProviderNameSpace>
   <Type>CustomScript</Type>
-  <Version>2.0.8</Version>
+  <Version>2.1.0</Version>
   <Label>Microsoft Azure Custom Script Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/pkg/download/blob_test.go
+++ b/pkg/download/blob_test.go
@@ -73,7 +73,7 @@ func Test_blobDownload_fails_badCreds(t *testing.T) {
 
 	status, _, err := Download(d)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "unexpected status code: got=403")
+	require.Contains(t, err.Error(), "unexpected status code: actual=403")
 	require.Equal(t, status, http.StatusForbidden)
 }
 

--- a/pkg/download/blob_test.go
+++ b/pkg/download/blob_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -70,9 +71,10 @@ func Test_blobDownload_fails_badCreds(t *testing.T) {
 		Container:   "foocontainer",
 	})
 
-	_, err := Download(d)
+	status, _, err := Download(d)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "unexpected status code: got=403")
+	require.Equal(t, status, http.StatusForbidden)
 }
 
 func Test_blobDownload_fails_urlNotFound(t *testing.T) {
@@ -82,7 +84,7 @@ func Test_blobDownload_fails_urlNotFound(t *testing.T) {
 		Container:   "foocontainer",
 	})
 
-	_, err := Download(d)
+	_, _, err := Download(d)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "http request failed:")
 }
@@ -121,7 +123,7 @@ func Test_blobDownload_actualBlob(t *testing.T) {
 		Blob:        name,
 		StorageBase: base,
 	})
-	body, err := Download(d)
+	_, body, err := Download(d)
 	require.Nil(t, err)
 	defer body.Close()
 	b, err := ioutil.ReadAll(body)

--- a/pkg/download/blobwithmsitoken.go
+++ b/pkg/download/blobwithmsitoken.go
@@ -1,23 +1,26 @@
 package download
 
 import (
-	"github.com/Azure/azure-extension-foundation/msi"
-	"net/http"
-	"github.com/pkg/errors"
 	"fmt"
+	"github.com/Azure/azure-extension-foundation/msi"
+	"github.com/pkg/errors"
+	"net/http"
+	url2 "net/url"
+	"strings"
 )
 
 const (
 	xMsVersionHeaderName = "x-ms-version"
-	xMsVersionValue = "2018-03-28"
+	xMsVersionValue      = "2018-03-28"
+	azureBlobDomainName  = "blob.core.windows.net"
 )
 
-type blobWithMsiToken struct{
-	url string
+type blobWithMsiToken struct {
+	url         string
 	msiProvider msi.MsiProvider
 }
 
-func (self *blobWithMsiToken) GetRequest() (*http.Request, error){
+func (self *blobWithMsiToken) GetRequest() (*http.Request, error) {
 	msi, err := self.msiProvider.GetMsi()
 	if err != nil {
 		return nil, err
@@ -25,16 +28,29 @@ func (self *blobWithMsiToken) GetRequest() (*http.Request, error){
 	if msi.AccessToken == "" {
 		return nil, errors.New("MSI token was empty")
 	}
+
 	request, err := http.NewRequest(http.MethodGet, self.url, nil)
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", msi.AccessToken))
-	request.Header.Set(xMsVersionHeaderName, xMsVersionValue)
+
+
+	if IsAzureStorageBlobUri(self.url) {
+		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", msi.AccessToken))
+		request.Header.Set(xMsVersionHeaderName, xMsVersionValue)
+	}
 	return request, nil
 }
 
+func NewBlobWithMsiDownload(url string, msiProvider msi.MsiProvider) Downloader {
+	return &blobWithMsiToken{url, msiProvider}
+}
 
-func NewBlobWithMsiDownload(url string, msiProvider msi.MsiProvider) Downloader{
-	return &blobWithMsiToken{url,msiProvider}
+func IsAzureStorageBlobUri(url string ) bool {
+	// TODO update this function
+	parsedUrl, err := url2.Parse(url)
+	if err != nil {
+		return false
+	}
+	return strings.HasSuffix(parsedUrl.Host, azureBlobDomainName)
 }

--- a/pkg/download/blobwithmsitoken.go
+++ b/pkg/download/blobwithmsitoken.go
@@ -61,7 +61,7 @@ func GetMsiProviderForStorageAccountsImplicitly(blobUri string) MsiProvider {
 		msi, err := msiProvider.GetMsiForResource(GetResourceNameFromBlobUri(blobUri))
 		if err != nil {
 			return msi, errors.Wrapf(err, "Unable to get managed identity. "+
-				"Please make sure that system assigned managed identity is enabled on the VM"+
+				"Please make sure that system assigned managed identity is enabled on the VM "+
 				"or user assigned identity is added to the system.")
 		}
 		return msi, nil

--- a/pkg/download/blobwithmsitoken.go
+++ b/pkg/download/blobwithmsitoken.go
@@ -34,7 +34,6 @@ func (self *blobWithMsiToken) GetRequest() (*http.Request, error) {
 		return nil, err
 	}
 
-
 	if IsAzureStorageBlobUri(self.url) {
 		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", msi.AccessToken))
 		request.Header.Set(xMsVersionHeaderName, xMsVersionValue)
@@ -46,7 +45,7 @@ func NewBlobWithMsiDownload(url string, msiProvider msi.MsiProvider) Downloader 
 	return &blobWithMsiToken{url, msiProvider}
 }
 
-func IsAzureStorageBlobUri(url string ) bool {
+func IsAzureStorageBlobUri(url string) bool {
 	// TODO update this function
 	parsedUrl, err := url2.Parse(url)
 	if err != nil {

--- a/pkg/download/blobwithmsitoken.go
+++ b/pkg/download/blobwithmsitoken.go
@@ -61,7 +61,7 @@ func GetMsiProviderForStorageAccountsWithClientId(clientId string) MsiProvider {
 
 func GetMsiProviderForStorageAccountsWithObjectId(objectId string) MsiProvider {
 	msiProvider := msi.NewMsiProvider(httputil.NewSecureHttpClient(httputil.DefaultRetryBehavior))
-	return func() (msi.Msi, error) { return msiProvider.GetMsiUsingClientId(objectId, storageResourceName) }
+	return func() (msi.Msi, error) { return msiProvider.GetMsiUsingObjectId(objectId, storageResourceName) }
 }
 
 func IsAzureStorageBlobUri(url string) bool {

--- a/pkg/download/blobwithmsitoken.go
+++ b/pkg/download/blobwithmsitoken.go
@@ -1,0 +1,40 @@
+package download
+
+import (
+	"github.com/Azure/azure-extension-foundation/msi"
+	"net/http"
+	"github.com/pkg/errors"
+	"fmt"
+)
+
+const (
+	xMsVersionHeaderName = "x-ms-version"
+	xMsVersionValue = "2018-03-28"
+)
+
+type blobWithMsiToken struct{
+	url string
+	msiProvider msi.MsiProvider
+}
+
+func (self *blobWithMsiToken) GetRequest() (*http.Request, error){
+	msi, err := self.msiProvider.GetMsi()
+	if err != nil {
+		return nil, err
+	}
+	if msi.AccessToken == "" {
+		return nil, errors.New("MSI token was empty")
+	}
+	request, err := http.NewRequest(http.MethodGet, self.url, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", msi.AccessToken))
+	request.Header.Set(xMsVersionHeaderName, xMsVersionValue)
+	return request, nil
+}
+
+
+func NewBlobWithMsiDownload(url string, msiProvider msi.MsiProvider) Downloader{
+	return &blobWithMsiToken{url,msiProvider}
+}

--- a/pkg/download/blobwithmsitoken.go
+++ b/pkg/download/blobwithmsitoken.go
@@ -57,20 +57,38 @@ func NewBlobWithMsiDownload(url string, msiProvider MsiProvider) Downloader {
 
 func GetMsiProviderForStorageAccountsImplicitly(blobUri string) MsiProvider {
 	msiProvider := msi.NewMsiProvider(httputil.NewSecureHttpClient(httputil.DefaultRetryBehavior))
-	return func() (msi.Msi, error) { return msiProvider.GetMsiForResource(GetResourceNameFromBlobUri(blobUri)) }
+	return func() (msi.Msi, error) {
+		msi, err := msiProvider.GetMsiForResource(GetResourceNameFromBlobUri(blobUri))
+		if err != nil {
+			return msi, errors.Wrapf(err, "Unable to get managed identity. "+
+				"Please make sure that system assigned managed identity is enabled on the VM"+
+				"or user assigned identity is added to the system.")
+		}
+		return msi, nil
+	}
 }
 
 func GetMsiProviderForStorageAccountsWithClientId(blobUri, clientId string) MsiProvider {
 	msiProvider := msi.NewMsiProvider(httputil.NewSecureHttpClient(httputil.DefaultRetryBehavior))
 	return func() (msi.Msi, error) {
-		return msiProvider.GetMsiUsingClientId(clientId, GetResourceNameFromBlobUri(blobUri))
+		msi, err := msiProvider.GetMsiUsingClientId(clientId, GetResourceNameFromBlobUri(blobUri))
+		if err != nil {
+			return msi, errors.Wrapf(err, "Unable to get managed identity with client id %s. "+
+				"Please make sure that the user assigned managed identity is added to the VM ", clientId)
+		}
+		return msi, nil
 	}
 }
 
 func GetMsiProviderForStorageAccountsWithObjectId(blobUri, objectId string) MsiProvider {
 	msiProvider := msi.NewMsiProvider(httputil.NewSecureHttpClient(httputil.DefaultRetryBehavior))
 	return func() (msi.Msi, error) {
-		return msiProvider.GetMsiUsingObjectId(objectId, GetResourceNameFromBlobUri(blobUri))
+		msi, err := msiProvider.GetMsiUsingObjectId(objectId, GetResourceNameFromBlobUri(blobUri))
+		if err != nil {
+			return msi, errors.Wrapf(err, "Unable to get managed identity with object id %s. "+
+				"Please make sure that the user assigned managed identity is added to the VM ", objectId)
+		}
+		return msi, nil
 	}
 }
 

--- a/pkg/download/blobwithmsitoken_test.go
+++ b/pkg/download/blobwithmsitoken_test.go
@@ -1,0 +1,1 @@
+package download

--- a/pkg/download/blobwithmsitoken_test.go
+++ b/pkg/download/blobwithmsitoken_test.go
@@ -8,12 +8,10 @@ import (
 	"testing"
 )
 
-
 // README for running this test
 // Assign/create an azure VM with system assigned or user assigned identity
 // this is the machine that you'll get the msiJson from
 // Assign "Storage Blob Data Reader" permissions to managed identity on a blob
-
 
 var msiJson = `` // place the msi json here e.g.
 // {"access_token":<access token>","client_id":"31b403aa-c364-4240-a7ff-d85fb6cd7232","expires_in":"28799",
@@ -24,8 +22,7 @@ var msiJson = `` // place the msi json here e.g.
 // Powershell command to get msi
 // Invoke-RestMethod -Method "GET" -Headers @{"Metadata"=$true} "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F" | ConvertTo-Json
 
-
-var blobUri = "" // set the blob to download here e.g. https://storageaccount.blob.core.windows.net/container/blobname
+var blobUri = ""         // set the blob to download here e.g. https://storageaccount.blob.core.windows.net/container/blobname
 var stringToLookFor = "" // the string to look for in you blob
 
 type mockMsiProvider struct { //implements MsiProvider

--- a/pkg/download/blobwithmsitoken_test.go
+++ b/pkg/download/blobwithmsitoken_test.go
@@ -1,1 +1,54 @@
 package download
+
+import (
+	"encoding/json"
+	"github.com/Azure/azure-extension-foundation/msi"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"testing"
+)
+
+
+// README for running this test
+// Assign/create an azure VM with system assigned or user assigned identity
+// this is the machine that you'll get the msiJson from
+// Assign "Storage Blob Data Reader" permissions to managed identity on a blob
+
+
+var msiJson = `` // place the msi json here e.g.
+// {"access_token":<access token>","client_id":"31b403aa-c364-4240-a7ff-d85fb6cd7232","expires_in":"28799",
+// "expires_on":"1563607134","ext_expires_in":"28799","not_before":"1563578034","resource":"https://storage.azure.com/",
+// "token_type":"Bearer"}
+// Linux command to get msi
+// curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F' -H Metadata:true
+// Powershell command to get msi
+// Invoke-RestMethod -Method "GET" -Headers @{"Metadata"=$true} "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F" | ConvertTo-Json
+
+
+var blobUri = "" // set the blob to download here e.g. https://storageaccount.blob.core.windows.net/container/blobname
+var stringToLookFor = "" // the string to look for in you blob
+
+type mockMsiProvider struct { //implements MsiProvider
+}
+
+func (self *mockMsiProvider) GetMsi() (msi.Msi, error) {
+	msi := msi.Msi{}
+	err := json.Unmarshal([]byte(msiJson), &msi)
+	return msi, err
+}
+
+func Test_realDownloadBlobWithMsiToken(t *testing.T) {
+	if msiJson == "" || blobUri == "" || stringToLookFor == "" {
+		t.Skip()
+	}
+	downloader := blobWithMsiToken{blobUri, new(mockMsiProvider)}
+	_, stream, err := Download(&downloader)
+	require.NoError(t, err, "File download failed")
+	defer stream.Close()
+
+	bytes, err := ioutil.ReadAll(stream)
+	require.NoError(t, err, "saving file stream to memory failed")
+
+	//verify
+	require.Contains(t, string(bytes), stringToLookFor)
+}

--- a/pkg/download/blobwithmsitoken_test.go
+++ b/pkg/download/blobwithmsitoken_test.go
@@ -8,19 +8,29 @@ import (
 	"testing"
 )
 
-// README for running this test
-// Assign/create an azure VM with system assigned or user assigned identity
+// README
+// to run this test, assign/create an azure VM with system assigned or user assigned identity
 // this is the machine that you'll get the msiJson from
-// Assign "Storage Blob Data Reader" permissions to managed identity on a blob
+// assign "Storage Blob Data Reader" permissions to managed identity on a blob
 
 var msiJson = `` // place the msi json here e.g.
 // {"access_token":<access token>","client_id":"31b403aa-c364-4240-a7ff-d85fb6cd7232","expires_in":"28799",
 // "expires_on":"1563607134","ext_expires_in":"28799","not_before":"1563578034","resource":"https://storage.azure.com/",
 // "token_type":"Bearer"}
+
 // Linux command to get msi
 // curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F' -H Metadata:true
+// curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F&client_id=<client_id>' -H Metadata:true
+// curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F&object_id=<object_id>' -H Metadata:true
+
 // Powershell command to get msi
 // Invoke-RestMethod -Method "GET" -Headers @{"Metadata"=$true} "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F" | ConvertTo-Json
+// Invoke-RestMethod -Method "GET" -Headers @{"Metadata"=$true} "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F&client_id=<client_id>" | ConvertTo-Json
+// Invoke-RestMethod -Method "GET" -Headers @{"Metadata"=$true} "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F&object_id=<object_id>" | ConvertTo-Json
+
+// the first command gets the system managed identity, or the user assigned identity if the VM has only one user assigned identity and no system assigned identity
+// the second command gets user assigned identity with its client id
+// the third command gets user assigned identity with its object id
 
 var blobUri = ""         // set the blob to download here e.g. https://storageaccount.blob.core.windows.net/container/blobname
 var stringToLookFor = "" // the string to look for in you blob
@@ -40,8 +50,6 @@ func Test_realDownloadBlobWithMsiToken(t *testing.T) {
 
 	bytes, err := ioutil.ReadAll(stream)
 	require.NoError(t, err, "saving file stream to memory failed")
-
-	//verify
 	require.Contains(t, string(bytes), stringToLookFor)
 }
 

--- a/pkg/download/blobwithmsitoken_test.go
+++ b/pkg/download/blobwithmsitoken_test.go
@@ -54,6 +54,8 @@ func Test_realDownloadBlobWithMsiToken(t *testing.T) {
 }
 
 func Test_isAzureStorageBlobUri(t *testing.T) {
-	require.True(t, IsAzureStorageBlobUri("https://a.blob.core.windows.net"))
+	require.True(t, IsAzureStorageBlobUri("https://a.blob.core.windows.net/container/blobname"))
+	require.True(t, IsAzureStorageBlobUri("http://mystorageaccountcn.blob.core.chinacloudapi.cn"))
+	require.True(t, IsAzureStorageBlobUri("https://blackforestsa.blob.core.couldapi.de/c/b/x"))
 	require.False(t, IsAzureStorageBlobUri("https://github.com/Azure-Samples/storage-blobs-go-quickstart/blob/master/README.md"))
 }

--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -52,5 +52,13 @@ func Download(d Downloader) (int, io.ReadCloser, error) {
 	if resp.StatusCode == http.StatusOK {
 		return resp.StatusCode, resp.Body, nil
 	}
-	return resp.StatusCode, nil, fmt.Errorf("unexpected status code: got=%d expected=%d", resp.StatusCode, http.StatusOK)
+
+	err = fmt.Errorf("unexpected status code: got=%d expected=%d", resp.StatusCode, http.StatusOK)
+	switch d.(type) {
+	case *blobWithMsiToken:
+		if resp.StatusCode == http.StatusForbidden {
+			return resp.StatusCode, nil, errors.Wrapf(err, "please ensure that the specified Managed Identity has read permissions to the storage blob")
+		}
+	}
+	return resp.StatusCode, nil, err
 }

--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -37,20 +37,20 @@ var (
 // Download retrieves a response body and checks the response status code to see
 // if it is 200 OK and then returns the response body. It issues a new request
 // every time called. It is caller's responsibility to close the response body.
-func Download(d Downloader) (io.ReadCloser, error) {
+func Download(d Downloader) (int, io.ReadCloser, error) {
 	req, err := d.GetRequest()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create the request")
+		return -1, nil, errors.Wrapf(err, "failed to create the request")
 	}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		err = urlutil.RemoveUrlFromErr(err)
-		return nil, errors.Wrapf(err, "http request failed")
+		return -1, nil, errors.Wrapf(err, "http request failed")
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: got=%d expected=%d", resp.StatusCode, http.StatusOK)
+	if resp.StatusCode == http.StatusOK {
+		return resp.StatusCode, resp.Body, nil
 	}
-	return resp.Body, nil
+	return resp.StatusCode, nil, fmt.Errorf("unexpected status code: got=%d expected=%d", resp.StatusCode, http.StatusOK)
 }

--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -53,11 +53,11 @@ func Download(d Downloader) (int, io.ReadCloser, error) {
 		return resp.StatusCode, resp.Body, nil
 	}
 
-	err = fmt.Errorf("unexpected status code: got=%d expected=%d", resp.StatusCode, http.StatusOK)
+	err = fmt.Errorf("unexpected status code: actual=%d expected=%d", resp.StatusCode, http.StatusOK)
 	switch d.(type) {
 	case *blobWithMsiToken:
-		if resp.StatusCode == http.StatusForbidden {
-			return resp.StatusCode, nil, errors.Wrapf(err, "please ensure that the specified Managed Identity has read permissions to the storage blob")
+		if resp.StatusCode == http.StatusNotFound {
+			return resp.StatusCode, nil, errors.Wrapf(err, "please ensure that the blob location in the fileUri setting exists and the specified Managed Identity has read permissions to the storage blob")
 		}
 	}
 	return resp.StatusCode, nil, err

--- a/pkg/download/downloader_test.go
+++ b/pkg/download/downloader_test.go
@@ -21,13 +21,13 @@ func (b *badDownloader) GetRequest() (*http.Request, error) {
 }
 
 func TestDownload_wrapsGetRequestError(t *testing.T) {
-	_, err := download.Download(new(badDownloader))
+	_, _, err := download.Download(new(badDownloader))
 	require.NotNil(t, err)
 	require.EqualError(t, err, "failed to create the request: expected error")
 }
 
 func TestDownload_wrapsHTTPError(t *testing.T) {
-	_, err := download.Download(download.NewURLDownload("bad url"))
+	_, _, err := download.Download(download.NewURLDownload("bad url"))
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "http request failed:")
 }
@@ -44,7 +44,7 @@ func TestDownload_badStatusCodeFails(t *testing.T) {
 		http.StatusBadRequest,
 		http.StatusUnauthorized,
 	} {
-		_, err := download.Download(download.NewURLDownload(fmt.Sprintf("%s/status/%d", srv.URL, code)))
+		_, _, err := download.Download(download.NewURLDownload(fmt.Sprintf("%s/status/%d", srv.URL, code)))
 		require.NotNil(t, err, "not failed for code:%d", code)
 		require.Contains(t, err.Error(), "unexpected status code", "wrong message for code %d", code)
 	}
@@ -54,7 +54,7 @@ func TestDownload_statusOKSucceeds(t *testing.T) {
 	srv := httptest.NewServer(httpbin.GetMux())
 	defer srv.Close()
 
-	body, err := download.Download(download.NewURLDownload(srv.URL + "/status/200"))
+	_, body, err := download.Download(download.NewURLDownload(srv.URL + "/status/200"))
 	require.Nil(t, err)
 	defer body.Close()
 	require.NotNil(t, body)
@@ -64,7 +64,7 @@ func TestDownload_retrievesBody(t *testing.T) {
 	srv := httptest.NewServer(httpbin.GetMux())
 	defer srv.Close()
 
-	body, err := download.Download(download.NewURLDownload(srv.URL + "/bytes/65536"))
+	_, body, err := download.Download(download.NewURLDownload(srv.URL + "/bytes/65536"))
 	require.Nil(t, err)
 	defer body.Close()
 	b, err := ioutil.ReadAll(body)
@@ -76,7 +76,7 @@ func TestDownload_bodyClosesWithoutError(t *testing.T) {
 	srv := httptest.NewServer(httpbin.GetMux())
 	defer srv.Close()
 
-	body, err := download.Download(download.NewURLDownload(srv.URL + "/get"))
+	_, body, err := download.Download(download.NewURLDownload(srv.URL + "/get"))
 	require.Nil(t, err)
 	require.Nil(t, body.Close(), "body should close fine")
 }

--- a/pkg/download/retry.go
+++ b/pkg/download/retry.go
@@ -48,7 +48,8 @@ func WithRetries(ctx *log.Context, downloaders []Downloader, sf SleepFunc) (io.R
 				out.Close()
 			}
 
-			if !isTransientHttpStatusCode(status) {
+			// status == -1 the value when there was no http request
+			if status != -1 && !isTransientHttpStatusCode(status) {
 				ctx.Log("info", fmt.Sprintf("downloader %T returned %v, skipping retries", d, status))
 				break
 			}

--- a/pkg/download/retry_test.go
+++ b/pkg/download/retry_test.go
@@ -79,16 +79,16 @@ func TestWithRetries_healingServer(t *testing.T) {
 	require.Equal(t, sleepSchedule[:3], []time.Duration(*sr))
 }
 
-func TestRetriesWith_SwitchDownloaderOn403(t *testing.T) {
+func TestRetriesWith_SwitchDownloaderOn404(t *testing.T) {
 	svr := httptest.NewServer(httpbin.GetMux())
 	hSvr := httptest.NewServer(new(healingServer))
 	defer svr.Close()
-	d403 := mockDownloader{0, svr.URL + "/status/403"}
+	d404 := mockDownloader{0, svr.URL + "/status/404"}
 	d200 := mockDownloader{0, hSvr.URL}
-	resp, err := download.WithRetries(nopLog(), []download.Downloader{&d403, &d200}, func(d time.Duration) { return })
+	resp, err := download.WithRetries(nopLog(), []download.Downloader{&d404, &d200}, func(d time.Duration) { return })
 	require.Nil(t, err, "should eventually succeed")
 	require.NotNil(t, resp, "response body exists")
-	require.Equal(t, d403.timesCalled, 1)
+	require.Equal(t, d404.timesCalled, 1)
 	require.Equal(t, d200.timesCalled, 4)
 }
 

--- a/pkg/download/retry_test.go
+++ b/pkg/download/retry_test.go
@@ -57,11 +57,11 @@ func TestWithRetries_failingBadStatusCode_validateSleeps(t *testing.T) {
 	srv := httptest.NewServer(httpbin.GetMux())
 	defer srv.Close()
 
-	d := download.NewURLDownload(srv.URL + "/status/404")
+	d := download.NewURLDownload(srv.URL + "/status/429")
 
 	sr := new(sleepRecorder)
 	_, err := download.WithRetries(nopLog(), []download.Downloader{d}, sr.Sleep)
-	require.EqualError(t, err, "unexpected status code: got=404 expected=200")
+	require.EqualError(t, err, "unexpected status code: actual=429 expected=200")
 
 	require.Equal(t, sleepSchedule, []time.Duration(*sr))
 }

--- a/pkg/download/retry_test.go
+++ b/pkg/download/retry_test.go
@@ -80,12 +80,12 @@ func TestWithRetries_healingServer(t *testing.T) {
 	require.Equal(t, sleepSchedule[:3], []time.Duration(*sr))
 }
 
-func TestRetriesWith_SwitchDownloaderOn403(t *testing.T){
+func TestRetriesWith_SwitchDownloaderOn403(t *testing.T) {
 	svr := httptest.NewServer(httpbin.GetMux())
 	defer svr.Close()
 	d403 := download.NewURLDownload(svr.URL + "/status/403")
-	d200 := download.NewBlobWithMsiDownload(svr.URL + "/status/200", &mockMsiProvider{})
-	resp, err  := download.WithRetries(nopLog(), []download.Downloader{d403, d200}, func (d time.Duration) {return})
+	d200 := download.NewBlobWithMsiDownload(svr.URL+"/status/200", &mockMsiProvider{})
+	resp, err := download.WithRetries(nopLog(), []download.Downloader{d403, d200}, func(d time.Duration) { return })
 	require.Nil(t, err, "should eventually succeed")
 	require.NotNil(t, resp, "response body exists")
 
@@ -98,7 +98,7 @@ type mockMsiProvider struct {
 }
 
 func (self *mockMsiProvider) GetMsi() (msi.Msi, error) {
-	return msi.Msi{AccessToken:"Dummy Token"}, nil
+	return msi.Msi{AccessToken: "Dummy Token"}, nil
 }
 
 // sleepRecorder keeps track of the durations of Sleep calls

--- a/pkg/download/retry_test.go
+++ b/pkg/download/retry_test.go
@@ -1,6 +1,7 @@
 package download_test
 
 import (
+	"github.com/Azure/azure-extension-foundation/msi"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,7 +38,7 @@ func TestWithRetries_noRetries(t *testing.T) {
 	d := download.NewURLDownload(srv.URL + "/status/200")
 
 	sr := new(sleepRecorder)
-	resp, err := download.WithRetries(nopLog(), d, sr.Sleep)
+	resp, err := download.WithRetries(nopLog(), []download.Downloader{d}, sr.Sleep)
 	require.Nil(t, err, "should not fail")
 	require.NotNil(t, resp, "response body exists")
 	require.Equal(t, []time.Duration(nil), []time.Duration(*sr), "sleep should not be called")
@@ -48,7 +49,7 @@ func TestWithRetries_failing_validateNumberOfCalls(t *testing.T) {
 	defer srv.Close()
 
 	bd := new(badDownloader)
-	_, err := download.WithRetries(nopLog(), bd, new(sleepRecorder).Sleep)
+	_, err := download.WithRetries(nopLog(), []download.Downloader{bd}, new(sleepRecorder).Sleep)
 	require.Contains(t, err.Error(), "expected error", "error is preserved")
 	require.EqualValues(t, 7, bd.calls, "calls exactly expRetryN times")
 }
@@ -60,7 +61,7 @@ func TestWithRetries_failingBadStatusCode_validateSleeps(t *testing.T) {
 	d := download.NewURLDownload(srv.URL + "/status/404")
 
 	sr := new(sleepRecorder)
-	_, err := download.WithRetries(nopLog(), d, sr.Sleep)
+	_, err := download.WithRetries(nopLog(), []download.Downloader{d}, sr.Sleep)
 	require.EqualError(t, err, "unexpected status code: got=404 expected=200")
 
 	require.Equal(t, sleepSchedule, []time.Duration(*sr))
@@ -72,14 +73,33 @@ func TestWithRetries_healingServer(t *testing.T) {
 
 	d := download.NewURLDownload(srv.URL)
 	sr := new(sleepRecorder)
-	resp, err := download.WithRetries(nopLog(), d, sr.Sleep)
+	resp, err := download.WithRetries(nopLog(), []download.Downloader{d}, sr.Sleep)
 	require.Nil(t, err, "should eventually succeed")
 	require.NotNil(t, resp, "response body exists")
 
 	require.Equal(t, sleepSchedule[:3], []time.Duration(*sr))
 }
 
+func TestRetriesWith_SwitchDownloaderOn403(t *testing.T){
+	svr := httptest.NewServer(httpbin.GetMux())
+	defer svr.Close()
+	d403 := download.NewURLDownload(svr.URL + "/status/403")
+	d200 := download.NewBlobWithMsiDownload(svr.URL + "/status/200", &mockMsiProvider{})
+	resp, err  := download.WithRetries(nopLog(), []download.Downloader{d403, d200}, func (d time.Duration) {return})
+	require.Nil(t, err, "should eventually succeed")
+	require.NotNil(t, resp, "response body exists")
+
+}
+
 // Test Utilities:
+
+//implements MsiProvider
+type mockMsiProvider struct {
+}
+
+func (self *mockMsiProvider) GetMsi() (msi.Msi, error) {
+	return msi.Msi{AccessToken:"Dummy Token"}, nil
+}
 
 // sleepRecorder keeps track of the durations of Sleep calls
 type sleepRecorder []time.Duration

--- a/pkg/download/save.go
+++ b/pkg/download/save.go
@@ -16,7 +16,7 @@ const (
 // given file. Directory of dst is not created by this function. If a file at
 // dst exists, it will be truncated. If a new file is created, mode is used to
 // set the permission bits. Written number of bytes are returned on success.
-func SaveTo(ctx *log.Context, d Downloader, dst string, mode os.FileMode) (int64, error) {
+func SaveTo(ctx *log.Context, d []Downloader, dst string, mode os.FileMode) (int64, error) {
 	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, mode)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to open file for writing")

--- a/pkg/download/save_test.go
+++ b/pkg/download/save_test.go
@@ -19,7 +19,7 @@ func TestSaveTo_invalidDir(t *testing.T) {
 
 	d := download.NewURLDownload(srv.URL + "/bytes/65536")
 
-	_, err := download.SaveTo(nopLog(), d, "/nonexistent-dir/dst", 0600)
+	_, err := download.SaveTo(nopLog(), []download.Downloader{d}, "/nonexistent-dir/dst", 0600)
 	require.Contains(t, err.Error(), "failed to open file for writing")
 }
 
@@ -33,7 +33,7 @@ func TestSave(t *testing.T) {
 
 	d := download.NewURLDownload(srv.URL + "/bytes/65536")
 	path := filepath.Join(dir, "test-file")
-	n, err := download.SaveTo(nopLog(), d, path, 0600)
+	n, err := download.SaveTo(nopLog(), []download.Downloader{d}, path, 0600)
 	require.Nil(t, err)
 	require.EqualValues(t, 65536, n)
 
@@ -52,9 +52,9 @@ func TestSave_truncates(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	path := filepath.Join(dir, "test-file")
-	_, err = download.SaveTo(nopLog(), download.NewURLDownload(srv.URL+"/bytes/65536"), path, 0600)
+	_, err = download.SaveTo(nopLog(), []download.Downloader{download.NewURLDownload(srv.URL+"/bytes/65536")}, path, 0600)
 	require.Nil(t, err)
-	_, err = download.SaveTo(nopLog(), download.NewURLDownload(srv.URL+"/bytes/128"), path, 0777)
+	_, err = download.SaveTo(nopLog(), []download.Downloader{download.NewURLDownload(srv.URL+"/bytes/128")}, path, 0777)
 	require.Nil(t, err)
 
 	fi, err := os.Stat(path)
@@ -74,7 +74,7 @@ func TestSave_largeFile(t *testing.T) {
 	size := 1024 * 1024 * 128 // 128 mb
 
 	path := filepath.Join(dir, "large-file")
-	n, err := download.SaveTo(nopLog(), download.NewURLDownload(srv.URL+"/bytes/"+fmt.Sprintf("%d", size)), path, 0600)
+	n, err := download.SaveTo(nopLog(), []download.Downloader{download.NewURLDownload(srv.URL+"/bytes/"+fmt.Sprintf("%d", size))}, path, 0600)
 	require.Nil(t, err)
 	require.EqualValues(t, size, n)
 

--- a/pkg/download/save_test.go
+++ b/pkg/download/save_test.go
@@ -52,9 +52,9 @@ func TestSave_truncates(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	path := filepath.Join(dir, "test-file")
-	_, err = download.SaveTo(nopLog(), []download.Downloader{download.NewURLDownload(srv.URL+"/bytes/65536")}, path, 0600)
+	_, err = download.SaveTo(nopLog(), []download.Downloader{download.NewURLDownload(srv.URL + "/bytes/65536")}, path, 0600)
 	require.Nil(t, err)
-	_, err = download.SaveTo(nopLog(), []download.Downloader{download.NewURLDownload(srv.URL+"/bytes/128")}, path, 0777)
+	_, err = download.SaveTo(nopLog(), []download.Downloader{download.NewURLDownload(srv.URL + "/bytes/128")}, path, 0777)
 	require.Nil(t, err)
 
 	fi, err := os.Stat(path)
@@ -74,7 +74,7 @@ func TestSave_largeFile(t *testing.T) {
 	size := 1024 * 1024 * 128 // 128 mb
 
 	path := filepath.Join(dir, "large-file")
-	n, err := download.SaveTo(nopLog(), []download.Downloader{download.NewURLDownload(srv.URL+"/bytes/"+fmt.Sprintf("%d", size))}, path, 0600)
+	n, err := download.SaveTo(nopLog(), []download.Downloader{download.NewURLDownload(srv.URL + "/bytes/" + fmt.Sprintf("%d", size))}, path, 0600)
 	require.Nil(t, err)
 	require.EqualValues(t, size, n)
 


### PR DESCRIPTION
Enable CSE linux to use managed identities to access azure storage blobs to download scripts.