### PR TITLE
Fix for text file busy error for custom-script-extension binary

### DIFF
--- a/misc/custom-script-shim
+++ b/misc/custom-script-shim
@@ -53,19 +53,22 @@ write_status() {
 check_binary_write_lock() {
     set +e # disable exit on non-zero return code
     local retry_attempts=0
-    while (( retry_attempts < 3 )); do
+    while (( retry_attempts < 10 )); do
         lsof_output="$(lsof ${bin})"
         if [ "$?" -eq 0 ]; then
             echo "${HANDLER_BIN} is open by the following processes: "
             echo "${lsof_output}"
             ((++retry_attempts))
-            echo "sleeping for 30 seconds before retry, attempt ${retry_attempts} of 3"
-            sleep 30
+            echo "sleeping for 3 seconds before retry, attempt ${retry_attempts} of 10"
+            sleep 3
         else
             set -e
             return 0 #Success path
         fi
     done
+    echo "Timed out waiting for lock on ${HANDLER_BIN}"
+    echo "File handle is still open by the following processes: "
+    echo "${lsof_output}"
     exit 1
 }
 

--- a/misc/custom-script-shim
+++ b/misc/custom-script-shim
@@ -50,6 +50,17 @@ write_status() {
 	fi
 }
 
+check_binary_write_lock() {
+    lsof_output="$(lsof ${bin})"
+
+    if [ "$?" -eq 0 ]; then
+        echo "${HANDLER_BIN} is open by the following processes: "
+        echo "${lsof_output}"
+        echo "attempting to kill processes with open file handles to ${HANDLER_BIN}"
+        lsof -t ${bin} | xargs kill -9
+    fi
+}
+
 if [ "$#" -ne 1 ]; then
     echo "Incorrect usage."
     echo "Usage: $0 <command>"
@@ -69,10 +80,12 @@ if [[ "$cmd" == "enable" ]]; then
     # to detach from the  handler process tree to avoid getting terminated 
     # after the 15-minute extension enabling timeout.
     write_status
+    check_binary_write_lock
     set -x
     nohup "$bin" $@ &
 else
     # execute the handler process as a child process
+    check_binary_write_lock
     set -x
     "$bin" $@
 fi

--- a/misc/custom-script-shim
+++ b/misc/custom-script-shim
@@ -52,12 +52,27 @@ write_status() {
 
 check_binary_write_lock() {
     set +e # disable exit on non-zero return code
+    local retry_attempts=0
+    while (( retry_attempts < 3 )); do
+        lsof_output="$(lsof ${bin})"
+        if [ "$?" -eq 0 ]; then
+            echo "${HANDLER_BIN} is open by the following processes: "
+            echo "${lsof_output}"
+            ((++retry_attempts))
+            echo "sleeping for 30 seconds before retry, attempt ${retry_attempts} of 3"
+            sleep 30
+        else
+            set -e
+            return 0
+        fi
+    done
+
+    # retries over, kill process(es) if needed
     lsof_output="$(lsof ${bin})"
     if [ "$?" -eq 0 ]; then
-        echo "${HANDLER_BIN} is open by the following processes: "
-        echo "${lsof_output}"
+    # If the wait timed out we need to write status file
+        echo "Timed out waiting for lock on ${HANDLER_BIN}"
         echo "attempting to kill processes with open file handles to ${HANDLER_BIN}"
-        # suppress output and errors in case process with file-handle is already dead and kill gets called without a process id
         lsof -t ${bin} | xargs kill -9 > /dev/null 2>&1
     fi
     set -e # re-enable exit on non-zero return code

--- a/misc/custom-script-shim
+++ b/misc/custom-script-shim
@@ -51,14 +51,16 @@ write_status() {
 }
 
 check_binary_write_lock() {
+    set +e # disable exit on non-zero return code
     lsof_output="$(lsof ${bin})"
-
     if [ "$?" -eq 0 ]; then
         echo "${HANDLER_BIN} is open by the following processes: "
         echo "${lsof_output}"
         echo "attempting to kill processes with open file handles to ${HANDLER_BIN}"
-        lsof -t ${bin} | xargs kill -9
+        # suppress output and errors in case process with file-handle is already dead and kill gets called without a process id
+        lsof -t ${bin} | xargs kill -9 > /dev/null 2>&1
     fi
+    set -e # re-enable exit on non-zero return code
 }
 
 if [ "$#" -ne 1 ]; then

--- a/misc/custom-script-shim
+++ b/misc/custom-script-shim
@@ -63,19 +63,10 @@ check_binary_write_lock() {
             sleep 30
         else
             set -e
-            return 0
+            return 0 #Success path
         fi
     done
-
-    # retries over, kill process(es) if needed
-    lsof_output="$(lsof ${bin})"
-    if [ "$?" -eq 0 ]; then
-    # If the wait timed out we need to write status file
-        echo "Timed out waiting for lock on ${HANDLER_BIN}"
-        echo "attempting to kill processes with open file handles to ${HANDLER_BIN}"
-        lsof -t ${bin} | xargs kill -9 > /dev/null 2>&1
-    fi
-    set -e # re-enable exit on non-zero return code
+    exit 1
 }
 
 if [ "$#" -ne 1 ]; then

--- a/misc/manifest.xml
+++ b/misc/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.Azure.Extensions</ProviderNameSpace>
   <Type>CustomScript</Type>
-  <Version>2.1.0</Version>
+  <Version>2.1.1</Version>
   <Label>Microsoft Azure Custom Script Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
Fix for text file busy custom-script-extension binary.
Use the shim file to detect open file handles to custom-script-extension binary, and kill the processes that own them before attempting to execute the binary.

