### PR TITLE
Updated wait behavior for open file handles to custom-script-extension binary

### DIFF
--- a/misc/custom-script-shim
+++ b/misc/custom-script-shim
@@ -52,13 +52,27 @@ write_status() {
 
 check_binary_write_lock() {
     set +e # disable exit on non-zero return code
-    lsof_output="$(lsof ${bin})"
-    if [ "$?" -eq 0 ]; then
-        echo "${HANDLER_BIN} is open by the following processes: "
-        echo "${lsof_output}"
-    fi
-    set -e
-    return 0
+    local retry_attempts=0
+    while (( retry_attempts < 10 )); do
+        lsof_result="$(lsof -F ac ${bin})"
+        lsof_return_code=$?
+        file_mode="$(echo "$lsof_result" | awk 'match($0, /^a(.*)$/) {print substr($0, RSTART+1, RLENGTH-1)}')"
+        lsof_output="$(lsof ${bin})"
+        if [ "$?" -eq 0 ]; then
+            echo "${HANDLER_BIN} is open by the following processes: "
+            echo "${lsof_output}"
+            ((++retry_attempts))
+            echo "sleeping for 3 seconds before retry, attempt ${retry_attempts} of 10"
+            sleep 3
+        else
+            set -e
+            return 0 #Success path
+        fi
+    done
+    echo "Timed out waiting for lock on ${HANDLER_BIN}"
+    echo "File handle is still open by the following processes: "
+    echo "${lsof_output}"
+    exit 1
 }
 
 if [ "$#" -ne 1 ]; then

--- a/misc/custom-script-shim
+++ b/misc/custom-script-shim
@@ -59,7 +59,7 @@ check_binary_write_lock() {
         if [ "$lsof_return_code" -eq 0 ]; then
             #"lsof -F" outputs results in more parse-able format, "-F ac" option prints access mode and command name for process
             #access mode and command names are prepended with a and c
-            file_mode="$(echo "$lsof_result" | awk 'match($0, /^a(.*)$/) {print substr($0, RSTART+1, RLENGTH-1)}')"
+            file_mode="$(echo "$lsof_result" | awk 'match($0, /^a(.*)$/) {print $0}')"
             process_name="$(echo "$lsof_result" | awk 'match($0, /^c(.*)$/) {print substr($0, RSTART+1, RLENGTH-1)}')"
 
             found_write_lock=0
@@ -67,18 +67,17 @@ check_binary_write_lock() {
             i=0
             for name in $process_name
             do
-                file_handle_mode=${file_mode_array[i]}
+                file_handle_mode=${file_mode_array[$i]}
                 echo "$name has access mode '$file_handle_mode' file handle on ${HANDLER_BIN}"
                 ## w and u are file descriptor modes for write and read/write access
-                if [[ $file_handle_mode == "w" ]] || [[ $file_handle_mode == "u" ]]; then
+                if [[ $file_handle_mode == "aw" ]] || [[ $file_handle_mode == "au" ]]; then
                     found_write_lock=1
                 fi
                 ((++i))
             done
             if [ "$found_write_lock" -eq 0 ]; then
                 # did not find write lock on any file no need to wait or retry
-                set -e
-                return 0 #Success path
+                break
             fi
             ((++retry_attempts))
             echo "waiting for process(es) with write handle on ${HANDLER_BIN}"
@@ -88,7 +87,7 @@ check_binary_write_lock() {
             break
         fi
     done
-    # do not wait for lock to release after retries expire, make a best effort attempt to start custom-script-extension
+    # do not return error if file descriptor is open after retries expire, make a best effort attempt to start custom-script-extension
     set -e
     return 0
 }

--- a/misc/custom-script-shim
+++ b/misc/custom-script-shim
@@ -56,23 +56,41 @@ check_binary_write_lock() {
     while (( retry_attempts < 10 )); do
         lsof_result="$(lsof -F ac ${bin})"
         lsof_return_code=$?
-        file_mode="$(echo "$lsof_result" | awk 'match($0, /^a(.*)$/) {print substr($0, RSTART+1, RLENGTH-1)}')"
-        lsof_output="$(lsof ${bin})"
-        if [ "$?" -eq 0 ]; then
-            echo "${HANDLER_BIN} is open by the following processes: "
-            echo "${lsof_output}"
+        if [ "$lsof_return_code" -eq 0 ]; then
+            #"lsof -F" outputs results in more parse-able format, "-F ac" option prints access mode and command name for process
+            #access mode and command names are prepended with a and c
+            file_mode="$(echo "$lsof_result" | awk 'match($0, /^a(.*)$/) {print substr($0, RSTART+1, RLENGTH-1)}')"
+            process_name="$(echo "$lsof_result" | awk 'match($0, /^c(.*)$/) {print substr($0, RSTART+1, RLENGTH-1)}')"
+
+            found_write_lock=0
+            file_mode_array=($file_mode)
+            i=0
+            for name in $process_name
+            do
+                file_handle_mode=${file_mode_array[i]}
+                echo "$name has a(n) $file_handle_mode lock on ${HANDLER_BIN} "
+                ## w and u are file descriptor modes for write and read/write access
+                if [[ $file_handle_mode == "w" ]] || [[ $file_handle_mode == "u" ]]; then
+                    found_write_lock=1
+                fi
+                ((++i))
+            done
+            if [ "$found_write_lock" -eq 0 ]; then
+                # did not find write lock on any file no need to wait or retry
+                set -e
+                return 0 #Success path
+            fi
             ((++retry_attempts))
+            echo "waiting for process(es) with write handle on ${HANDLER_BIN}"
             echo "sleeping for 3 seconds before retry, attempt ${retry_attempts} of 10"
             sleep 3
         else
-            set -e
-            return 0 #Success path
+            break
         fi
     done
-    echo "Timed out waiting for lock on ${HANDLER_BIN}"
-    echo "File handle is still open by the following processes: "
-    echo "${lsof_output}"
-    exit 1
+    # do not wait for lock to release after retries expire, make a best effort attempt to start custom-script-extension
+    set -e
+    return 0
 }
 
 if [ "$#" -ne 1 ]; then

--- a/misc/custom-script-shim
+++ b/misc/custom-script-shim
@@ -52,24 +52,13 @@ write_status() {
 
 check_binary_write_lock() {
     set +e # disable exit on non-zero return code
-    local retry_attempts=0
-    while (( retry_attempts < 10 )); do
-        lsof_output="$(lsof ${bin})"
-        if [ "$?" -eq 0 ]; then
-            echo "${HANDLER_BIN} is open by the following processes: "
-            echo "${lsof_output}"
-            ((++retry_attempts))
-            echo "sleeping for 3 seconds before retry, attempt ${retry_attempts} of 10"
-            sleep 3
-        else
-            set -e
-            return 0 #Success path
-        fi
-    done
-    echo "Timed out waiting for lock on ${HANDLER_BIN}"
-    echo "File handle is still open by the following processes: "
-    echo "${lsof_output}"
-    exit 1
+    lsof_output="$(lsof ${bin})"
+    if [ "$?" -eq 0 ]; then
+        echo "${HANDLER_BIN} is open by the following processes: "
+        echo "${lsof_output}"
+    fi
+    set -e
+    return 0
 }
 
 if [ "$#" -ne 1 ]; then

--- a/misc/custom-script-shim
+++ b/misc/custom-script-shim
@@ -68,7 +68,7 @@ check_binary_write_lock() {
             for name in $process_name
             do
                 file_handle_mode=${file_mode_array[i]}
-                echo "$name has a(n) $file_handle_mode lock on ${HANDLER_BIN} "
+                echo "$name has access mode '$file_handle_mode' file handle on ${HANDLER_BIN}"
                 ## w and u are file descriptor modes for write and read/write access
                 if [[ $file_handle_mode == "w" ]] || [[ $file_handle_mode == "u" ]]; then
                     found_write_lock=1

--- a/misc/manifest.xml
+++ b/misc/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.Azure.Extensions</ProviderNameSpace>
   <Type>CustomScript</Type>
-  <Version>2.1.1</Version>
+  <Version>2.1.2</Version>
   <Label>Microsoft Azure Custom Script Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/pkg/download/blobwithmsitoken.go
+++ b/pkg/download/blobwithmsitoken.go
@@ -60,7 +60,7 @@ func GetMsiProviderForStorageAccountsImplicitly(blobUri string) MsiProvider {
 	return func() (msi.Msi, error) {
 		msi, err := msiProvider.GetMsiForResource(GetResourceNameFromBlobUri(blobUri))
 		if err != nil {
-			return msi, errors.Wrapf(err, "Unable to get managed identity. "+
+			return msi, fmt.Errorf("Unable to get managed identity. "+
 				"Please make sure that system assigned managed identity is enabled on the VM "+
 				"or user assigned identity is added to the system.")
 		}
@@ -73,7 +73,7 @@ func GetMsiProviderForStorageAccountsWithClientId(blobUri, clientId string) MsiP
 	return func() (msi.Msi, error) {
 		msi, err := msiProvider.GetMsiUsingClientId(clientId, GetResourceNameFromBlobUri(blobUri))
 		if err != nil {
-			return msi, errors.Wrapf(err, "Unable to get managed identity with client id %s. "+
+			return msi, fmt.Errorf("Unable to get managed identity with client id %s. "+
 				"Please make sure that the user assigned managed identity is added to the VM ", clientId)
 		}
 		return msi, nil
@@ -85,7 +85,7 @@ func GetMsiProviderForStorageAccountsWithObjectId(blobUri, objectId string) MsiP
 	return func() (msi.Msi, error) {
 		msi, err := msiProvider.GetMsiUsingObjectId(objectId, GetResourceNameFromBlobUri(blobUri))
 		if err != nil {
-			return msi, errors.Wrapf(err, "Unable to get managed identity with object id %s. "+
+			return msi, fmt.Errorf("Unable to get managed identity with object id %s. "+
 				"Please make sure that the user assigned managed identity is added to the VM ", objectId)
 		}
 		return msi, nil

--- a/pkg/download/blobwithmsitoken.go
+++ b/pkg/download/blobwithmsitoken.go
@@ -60,8 +60,8 @@ func GetMsiProviderForStorageAccountsImplicitly(blobUri string) MsiProvider {
 	return func() (msi.Msi, error) {
 		msi, err := msiProvider.GetMsiForResource(GetResourceNameFromBlobUri(blobUri))
 		if err != nil {
-			return msi, fmt.Errorf("Unable to get managed identity. "+
-				"Please make sure that system assigned managed identity is enabled on the VM "+
+			return msi, fmt.Errorf("Unable to get managed identity. " +
+				"Please make sure that system assigned managed identity is enabled on the VM " +
 				"or user assigned identity is added to the system.")
 		}
 		return msi, nil


### PR DESCRIPTION
Updated wait behavior for open file handles to custom-script-extension binary

Also removed call stack from the error message which is generated when user specifies a non existent managed identity.