### PR TITLE
run script on update

### DIFF
--- a/main/cmds.go
+++ b/main/cmds.go
@@ -130,11 +130,12 @@ func enablePre(ctx *log.Context, hEnv HandlerEnvironment, seqNum int) error {
 		return errors.Wrap(err, "failed to process sequence number")
 	} else if shouldExit {
 		//check if there's a new settings file. ex: ext updates and new script is passed in 
-	    newScript, err := checkNewSettings(ctx, hEnv, mostRecentSequence)
-		if !newScript || err != nil {
+		// and updates mostrecent seq number
+	    newScript := checkNewSettings(ctx, hEnv.HandlerEnvironment.ConfigFolder, mostRecentSequence)
+		if !newScript {
 			ctx.Log("event", "exit", "message", "the script configuration has already been processed, will not run again")
+			os.Exit(0)
 		} 
-		os.Exit(0)
 	}
 	return nil
 }

--- a/main/handlersettings_test.go
+++ b/main/handlersettings_test.go
@@ -195,12 +195,51 @@ func Test_toJSONUmarshallForManagedIdentity(t *testing.T) {
 	require.Error(t, h.validate(), "settings should be invalid")
 }
 
-func Test_EnableWithUpgrade() {
-	//receives a script
+func Test_EnableWithUpgrade(t *testing T) {
+	//set up logging
+	ctx := log.NewContext(log.NewSyncLogger(log.NewLogfmtLogger(
+		os.Stdout))).With("time", log.DefaultTimestamp).With("version", VersionString())
 
-	//there is an update 
 
-	//make sure that script it run
+	//create most recent sequence file, in this case we can set seq num to 1
+	// 0 - install, 1 - update (since it'll pull from status folder)
+	dataFolder := "/data"
+	err := os.MkdirAll(dataFolder, os.ModeDir)
+	if err != nil {
+		return err
+	}
+	seqNum := "1"
+	mrseqPath := filepath.Join(dataFolder, "mrs.txt")
+	mrseqFile := os.Create(mrseqPath)
+	if err != nil {
+		return err
+	}
+	size, err := file.Write(seqNum)
+	if err != nil || size == 0 {
+		return err
+	}
 
-	// we woooo 
+	//manually add a setting file 
+	//represents a new script being passed thru 
+	folderPath := "/config"
+	err := os.MkdirAll(folderPath, os.ModeDir)
+	if err != nil {
+		return err 
+	}
+	testContent := "beep boop"
+	fileName := filepath.Join(folderPath, "2.settings")
+	file, err := os.Create(fileName)
+	if err != nil {
+		return err
+	}
+	size, err := file.Write(testContent)
+	if err != nil || size == 0 {
+		return err
+	}
+
+	//compare the seq num from settings folder to the one saved in mrseq file
+	//if new num, update the number in file
+	check := checkNewSettings(ctx, hnv, mrseqPath) 
+
+	require.Equal(t, check, true)
 }

--- a/main/handlersettings_test.go
+++ b/main/handlersettings_test.go
@@ -194,3 +194,13 @@ func Test_toJSONUmarshallForManagedIdentity(t *testing.T) {
 	h = handlerSettings{publicSettings{}, *protSettings}
 	require.Error(t, h.validate(), "settings should be invalid")
 }
+
+func Test_EnableWithUpgrade() {
+	//receives a script
+
+	//there is an update 
+
+	//make sure that script it run
+
+	// we woooo 
+}

--- a/main/handlersettingscommon.go
+++ b/main/handlersettingscommon.go
@@ -9,8 +9,6 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"path/filepath"
-	"strings"
-	"strconv"
 	
 	"github.com/Azure/custom-script-extension-linux/pkg/seqnum"
 	"github.com/go-kit/kit/log"
@@ -146,18 +144,27 @@ func unmarshalProtectedSettings(configFolder string, hs handlerSettingsCommon, v
 	return nil
 }
 
-func checkNewSettings(ctx *log.Context, hEnv HandlerEnvironment, mrseqPath string) (bool, error) {
-	//get all files, and order them
-	configFolder, err := ioutil.ReadDir(hEnv.HandlerEnvironment.ConfigFolder)
+func checkNewSettings(ctx *log.Context, configFolder string, mrseqPath string) bool {
+	recentSeqNum, err := FindSeqNumConfig(configFolder)
 
 	if err != nil {
-		ctx.Log("message", "cannot get settings folder")
+		ctx.Log("message", "cannot get latest seq num from config folder")
 	}
-
-	topFile := configFolder[len(configFolder)-1].Name()
-	recentSeqNum, _ := strconv.Atoi(strings.TrimSuffix(topFile, ".settings"))
 
 	newSeq, err := seqnum.IsSmallerThan(mrseqPath, recentSeqNum)
 
-	return newSeq, err
+	if err != nil {
+		ctx.Log("message", "cannot compare most recent sequence number")
+	}
+
+	if newSeq {
+		ctx.Log("message", "saving most recent seq number...")
+		err := seqnum.Set(mrseqPath, recentSeqNum)
+		if err != nil {
+			ctx.Log("message", "couldn't update sequence number")
+		}
+	}
+
+
+	return newSeq
 }

--- a/main/handlersettingscommon.go
+++ b/main/handlersettingscommon.go
@@ -164,7 +164,6 @@ func checkNewSettings(ctx *log.Context, configFolder string, mrseqPath string) b
 			ctx.Log("message", "couldn't update sequence number")
 		}
 	}
-
-
+	
 	return newSeq
 }

--- a/main/main.go
+++ b/main/main.go
@@ -71,7 +71,7 @@ func main() {
 	ctx.Log("event", "start")
 	if cmd.pre != nil {
 		ctx.Log("event", "pre-check")
-		if err := cmd.pre(ctx, seqNum); err != nil {
+		if err := cmd.pre(ctx, hEnv, seqNum); err != nil {
 			ctx.Log("event", "pre-check failed", "error", err)
 			os.Exit(cmd.failExitCode)
 		}


### PR DESCRIPTION
currently script is not being run when updating extension, 

--> currently sequence number is checked using status file, once that check is complete, added check if there's a new settings file (new sequence number) 
if there is a new setting file, then new seq number is written to mrseq file and the script should get executed 
