### PR TITLE
Track Request ID, Response ID, and Response Code + Add response-code-specific error messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ahmetalpbalkan/go-httpbin v0.0.0-20160706084156-8817b883dae1
 	github.com/go-kit/kit v0.12.0
 	github.com/go-stack/stack v1.5.2 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/context v0.0.0-20160525203319-aed02d124ae4 // indirect
 	github.com/gorilla/mux v0.0.0-20160605233521-9fa818a44c2b // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNV
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-stack/stack v1.5.2 h1:5sTB/0oZM2O31k/N1IRwxxVXzLIt5NF2Aqx/2gWI9OY=
 github.com/go-stack/stack v1.5.2/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/context v0.0.0-20160525203319-aed02d124ae4 h1:3nOfQt8sRPYbXORD5tJ8YyQ3HlL2Jt3LJ2U17CbNh6I=
 github.com/gorilla/context v0.0.0-20160525203319-aed02d124ae4/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v0.0.0-20160605233521-9fa818a44c2b h1:OFvZV3a+25cGJH9dETHw0nk0wV6hLZI7IJijOkXEFS0=

--- a/main/files.go
+++ b/main/files.go
@@ -38,7 +38,6 @@ func downloadAndProcessURL(ctx *log.Context, url, downloadDir string, cfg *handl
 	fp := filepath.Join(downloadDir, fn)
 	const mode = 0500 // we assume users download scripts to execute
 	if _, err := download.SaveTo(ctx, dl, fp, mode); err != nil {
-		//TODO: Track response id and code
 		return err
 	}
 

--- a/main/files.go
+++ b/main/files.go
@@ -38,6 +38,7 @@ func downloadAndProcessURL(ctx *log.Context, url, downloadDir string, cfg *handl
 	fp := filepath.Join(downloadDir, fn)
 	const mode = 0500 // we assume users download scripts to execute
 	if _, err := download.SaveTo(ctx, dl, fp, mode); err != nil {
+		//TODO: Track response id and code
 		return err
 	}
 

--- a/pkg/download/blob.go
+++ b/pkg/download/blob.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/custom-script-extension-linux/pkg/blobutil"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -25,7 +26,11 @@ func (b blobDownload) GetRequest() (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	return http.NewRequest("GET", url, nil)
+	req, error := http.NewRequest("GET", url, nil)
+	if req != nil {
+		req.Header.Set(xMsClientRequestIdHeaderName, uuid.New().String())
+	}
+	return req, error
 }
 
 // getURL returns publicly downloadable URL of the Azure Blob

--- a/pkg/download/blob_test.go
+++ b/pkg/download/blob_test.go
@@ -19,7 +19,7 @@ func Test_blobDownload_validateInputs(t *testing.T) {
 		getURL() (string, error)
 	}
 
-	_, err := NewBlobDownload("", "", blobutil.AzureBlobRef{}).GetRequest()
+	req, err := NewBlobDownload("", "", blobutil.AzureBlobRef{}).GetRequest()
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "failed to initialize azure storage client")
 	require.Contains(t, err.Error(), "account name required")
@@ -33,9 +33,10 @@ func Test_blobDownload_validateInputs(t *testing.T) {
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "failed to initialize azure storage client")
 
-	_, err = NewBlobDownload("account", "Zm9vCg==", blobutil.AzureBlobRef{
+	req, err = NewBlobDownload("account", "Zm9vCg==", blobutil.AzureBlobRef{
 		StorageBase: storage.DefaultBaseURL,
 	}).GetRequest()
+	fmt.Println("request ID: " + req.Header.Get(xMsClientRequestIdHeaderName))
 	require.Nil(t, err)
 }
 
@@ -73,7 +74,8 @@ func Test_blobDownload_fails_badCreds(t *testing.T) {
 
 	status, _, err := Download(d)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "unexpected status code: actual=403")
+	require.Contains(t, err.Error(), "Please verify the machine has network connectivity")
+	require.Contains(t, err.Error(), "403")
 	require.Equal(t, status, http.StatusForbidden)
 }
 

--- a/pkg/download/blobwithmsitoken.go
+++ b/pkg/download/blobwithmsitoken.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Azure/azure-extension-foundation/httputil"
 	"github.com/Azure/azure-extension-foundation/msi"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -43,6 +44,7 @@ func (self *blobWithMsiToken) GetRequest() (*http.Request, error) {
 		return nil, err
 	}
 
+	request.Header.Set(xMsClientRequestIdHeaderName, uuid.New().String())
 	if IsAzureStorageBlobUri(self.url) {
 		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", msi.AccessToken))
 		request.Header.Set(xMsVersionHeaderName, xMsVersionValue)

--- a/pkg/download/blobwithmsitoken_test.go
+++ b/pkg/download/blobwithmsitoken_test.go
@@ -54,6 +54,23 @@ func Test_realDownloadBlobWithMsiToken(t *testing.T) {
 	require.Contains(t, string(bytes), stringToLookFor)
 }
 
+func Test_realDownloadBlobWithMsiToken404(t *testing.T) {
+	if msiJson == "" || blobUri == "" || stringToLookFor == "" {
+		t.Skip()
+	}
+	var badBlobUri = blobUri[0 : len(blobUri)-1]
+	downloader := blobWithMsiToken{badBlobUri, func() (msi.Msi, error) {
+		msi := msi.Msi{}
+		err := json.Unmarshal([]byte(msiJson), &msi)
+		return msi, err
+	}}
+	_, stream, err := Download(testctx, &downloader)
+	require.NotNil(t, err, "File download succeeded but was not supposed to")
+	require.Contains(t, err.Error(), MsiDownload404ErrorString)
+	require.Contains(t, err.Error(), "Service request ID:") // should have a service request ID since downloading from Azure Storage
+	defer stream.Close()
+}
+
 func Test_isAzureStorageBlobUri(t *testing.T) {
 	require.True(t, IsAzureStorageBlobUri("https://a.blob.core.windows.net/container/blobname"))
 	require.True(t, IsAzureStorageBlobUri("http://mystorageaccountcn.blob.core.chinacloudapi.cn"))

--- a/pkg/download/blobwithmsitoken_test.go
+++ b/pkg/download/blobwithmsitoken_test.go
@@ -3,6 +3,7 @@ package download
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"testing"
 
 	"github.com/Azure/azure-extension-foundation/msi"
@@ -64,11 +65,11 @@ func Test_realDownloadBlobWithMsiToken404(t *testing.T) {
 		err := json.Unmarshal([]byte(msiJson), &msi)
 		return msi, err
 	}}
-	_, stream, err := Download(testctx, &downloader)
+	code, _, err := Download(testctx, &downloader)
 	require.NotNil(t, err, "File download succeeded but was not supposed to")
+	require.Equal(t, http.StatusNotFound, code)
 	require.Contains(t, err.Error(), MsiDownload404ErrorString)
 	require.Contains(t, err.Error(), "Service request ID:") // should have a service request ID since downloading from Azure Storage
-	defer stream.Close()
 }
 
 func Test_isAzureStorageBlobUri(t *testing.T) {

--- a/pkg/download/blobwithmsitoken_test.go
+++ b/pkg/download/blobwithmsitoken_test.go
@@ -2,10 +2,11 @@ package download
 
 import (
 	"encoding/json"
-	"github.com/Azure/azure-extension-foundation/msi"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"testing"
+
+	"github.com/Azure/azure-extension-foundation/msi"
+	"github.com/stretchr/testify/require"
 )
 
 // README
@@ -44,7 +45,7 @@ func Test_realDownloadBlobWithMsiToken(t *testing.T) {
 		err := json.Unmarshal([]byte(msiJson), &msi)
 		return msi, err
 	}}
-	_, stream, err := Download(&downloader)
+	_, stream, err := Download(testctx, &downloader)
 	require.NoError(t, err, "File download failed")
 	defer stream.Close()
 

--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -49,7 +49,6 @@ func Download(ctx *log.Context, d Downloader) (int, io.ReadCloser, error) {
 	if err != nil {
 		return -1, nil, errors.Wrapf(err, "failed to create http request")
 	}
-
 	requestID := req.Header.Get(xMsClientRequestIdHeaderName)
 	if len(requestID) > 0 {
 		ctx.Log("info", fmt.Sprintf("starting download with client request ID %s", requestID))
@@ -76,29 +75,34 @@ func Download(ctx *log.Context, d Downloader) (int, io.ReadCloser, error) {
 		}
 		break
 	default:
+		uri := req.URL.Host //"string"
 		switch resp.StatusCode {
 		case http.StatusUnauthorized:
-			errString = fmt.Sprintf("CustomScript failed to download the blob [REDACTED] because access was denied. Please fix the blob permissions and try again, the response code returned was: %q",
-				resp.Status,
-			)
+			errString = fmt.Sprintf("CustomScript failed to download the file from %s because access was denied. Please fix the blob permissions and try again, the response code and message returned were: %q",
+				uri,
+				resp.Status)
 		case http.StatusNotFound:
-			errString = fmt.Sprintf("CustomScript failed to download the blob [REDACTED] because it does not exist. Please create the blob and try again, the response code returned was %q",
+			errString = fmt.Sprintf("CustomScript failed to download the file from %s because it does not exist. Please create the blob and try again, the response code and message returned were: %q",
+				uri,
 				resp.Status)
 
 		case http.StatusBadRequest:
-			errString = fmt.Sprintf("CustomScript failed to download the blob [REDACTED] because parts of the request were incorrectly formatted, missing, and/or invalid. The response code returned was: %q",
+			errString = fmt.Sprintf("CustomScript failed to download the file from %s because parts of the request were incorrectly formatted, missing, and/or invalid. The response code and message returned were: %q",
+				uri,
 				resp.Status)
 
 		case http.StatusInternalServerError:
-			errString = fmt.Sprintf("CustomScript failed to download the blob [REDACTED] due to an issue with storage. The response code returned was: %q",
+			errString = fmt.Sprintf("CustomScript failed to download the file from %s due to an issue with storage. The response code and message returned were: %q",
+				uri,
 				resp.Status)
 		default:
-			errString = fmt.Sprintf("CustomScript failed to download the blob [REDACTED] because the server returned a response of %q. Please verify the machine has network connectivity.",
+			errString = fmt.Sprintf("CustomScript failed to download the file from %s because the server returned a response code and message of %q Please verify the machine has network connectivity.",
+				uri,
 				resp.Status)
 		}
 	}
 	if len(requestId) > 0 {
-		errString += fmt.Sprintf(" (Service request ID: %s", requestId)
+		errString += fmt.Sprintf(" (Service request ID: %s)", requestId)
 	}
 	return resp.StatusCode, nil, fmt.Errorf(errString)
 }

--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -75,29 +75,29 @@ func Download(ctx *log.Context, d Downloader) (int, io.ReadCloser, error) {
 		}
 		break
 	default:
-		uri := req.URL.Host //"string"
+		hostname := req.URL.Host //"string"
 		switch resp.StatusCode {
 		case http.StatusUnauthorized:
 			errString = fmt.Sprintf("CustomScript failed to download the file from %s because access was denied. Please fix the blob permissions and try again, the response code and message returned were: %q",
-				uri,
+				hostname,
 				resp.Status)
 		case http.StatusNotFound:
 			errString = fmt.Sprintf("CustomScript failed to download the file from %s because it does not exist. Please create the blob and try again, the response code and message returned were: %q",
-				uri,
+				hostname,
 				resp.Status)
 
 		case http.StatusBadRequest:
 			errString = fmt.Sprintf("CustomScript failed to download the file from %s because parts of the request were incorrectly formatted, missing, and/or invalid. The response code and message returned were: %q",
-				uri,
+				hostname,
 				resp.Status)
 
 		case http.StatusInternalServerError:
 			errString = fmt.Sprintf("CustomScript failed to download the file from %s due to an issue with storage. The response code and message returned were: %q",
-				uri,
+				hostname,
 				resp.Status)
 		default:
 			errString = fmt.Sprintf("CustomScript failed to download the file from %s because the server returned a response code and message of %q Please verify the machine has network connectivity.",
-				uri,
+				hostname,
 				resp.Status)
 		}
 	}

--- a/pkg/download/downloader_test.go
+++ b/pkg/download/downloader_test.go
@@ -40,7 +40,8 @@ func TestDownload_wrapsHTTPError(t *testing.T) {
 	require.Contains(t, err.Error(), "http request failed:")
 }
 
-func TestDownload_badStatusCodeFails(t *testing.T) {
+// This test is only to make sure that formatting of error messages for specific codes is correct
+func TestDownload_wrapsCommonErrorCodes(t *testing.T) {
 	srv := httptest.NewServer(httpbin.GetMux())
 	defer srv.Close()
 
@@ -52,9 +53,10 @@ func TestDownload_badStatusCodeFails(t *testing.T) {
 		http.StatusBadRequest,
 		http.StatusUnauthorized,
 	} {
-		_, _, err := download.Download(testctx, download.NewURLDownload(fmt.Sprintf("%s/status/%d", srv.URL, code)))
+		respCode, _, err := download.Download(testctx, download.NewURLDownload(fmt.Sprintf("%s/status/%d", srv.URL, code)))
 		require.NotNil(t, err, "not failed for code:%d", code)
-		switch code {
+		require.Equal(t, code, respCode)
+		switch respCode {
 		case http.StatusNotFound:
 			require.Contains(t, err.Error(), "because it does not exist")
 		case http.StatusForbidden:
@@ -66,7 +68,6 @@ func TestDownload_badStatusCodeFails(t *testing.T) {
 		case http.StatusUnauthorized:
 			require.Contains(t, err.Error(), "because access was denied")
 		}
-		//require.Contains(t, err.Error(), "unexpected status code", "wrong message for code %d", code)
 	}
 }
 

--- a/pkg/download/downloader_test.go
+++ b/pkg/download/downloader_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-extension-foundation/msi"
+	"github.com/go-kit/kit/log"
 
 	"github.com/Azure/custom-script-extension-linux/pkg/download"
 	"github.com/ahmetalpbalkan/go-httpbin"
@@ -18,19 +19,23 @@ import (
 
 type badDownloader struct{ calls int }
 
+var (
+	testctx = log.NewContext(log.NewNopLogger())
+)
+
 func (b *badDownloader) GetRequest() (*http.Request, error) {
 	b.calls++
 	return nil, errors.New("expected error")
 }
 
 func TestDownload_wrapsGetRequestError(t *testing.T) {
-	_, _, err := download.Download(new(badDownloader))
+	_, _, err := download.Download(testctx, new(badDownloader))
 	require.NotNil(t, err)
 	require.EqualError(t, err, "failed to create http request: expected error")
 }
 
 func TestDownload_wrapsHTTPError(t *testing.T) {
-	_, _, err := download.Download(download.NewURLDownload("bad url"))
+	_, _, err := download.Download(testctx, download.NewURLDownload("bad url"))
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "http request failed:")
 }
@@ -47,7 +52,7 @@ func TestDownload_badStatusCodeFails(t *testing.T) {
 		http.StatusBadRequest,
 		http.StatusUnauthorized,
 	} {
-		_, _, err := download.Download(download.NewURLDownload(fmt.Sprintf("%s/status/%d", srv.URL, code)))
+		_, _, err := download.Download(testctx, download.NewURLDownload(fmt.Sprintf("%s/status/%d", srv.URL, code)))
 		require.NotNil(t, err, "not failed for code:%d", code)
 		switch code {
 		case http.StatusNotFound:
@@ -69,7 +74,7 @@ func TestDownload_statusOKSucceeds(t *testing.T) {
 	srv := httptest.NewServer(httpbin.GetMux())
 	defer srv.Close()
 
-	_, body, err := download.Download(download.NewURLDownload(srv.URL + "/status/200"))
+	_, body, err := download.Download(testctx, download.NewURLDownload(srv.URL+"/status/200"))
 	require.Nil(t, err)
 	defer body.Close()
 	require.NotNil(t, body)
@@ -84,13 +89,13 @@ func TestDowload_msiDownloaderErrorMessage(t *testing.T) {
 
 	msiDownloader404 := download.NewBlobWithMsiDownload(srv.URL+"/status/404", mockMsiProvider)
 
-	returnCode, body, err := download.Download(msiDownloader404)
+	returnCode, body, err := download.Download(testctx, msiDownloader404)
 	require.True(t, strings.Contains(err.Error(), download.MsiDownload404ErrorString), "error string doesn't contain the correct message")
 	require.Nil(t, body, "body is not nil for failed download")
 	require.Equal(t, 404, returnCode, "return code was not 404")
 
 	msiDownloader403 := download.NewBlobWithMsiDownload(srv.URL+"/status/403", mockMsiProvider)
-	returnCode, body, err = download.Download(msiDownloader403)
+	returnCode, body, err = download.Download(testctx, msiDownloader403)
 	require.True(t, strings.Contains(err.Error(), download.MsiDownload403ErrorString), "error string doesn't contain the correct message")
 	require.Nil(t, body, "body is not nil for failed download")
 	require.Equal(t, 403, returnCode, "return code was not 403")
@@ -101,7 +106,7 @@ func TestDownload_retrievesBody(t *testing.T) {
 	srv := httptest.NewServer(httpbin.GetMux())
 	defer srv.Close()
 
-	_, body, err := download.Download(download.NewURLDownload(srv.URL + "/bytes/65536"))
+	_, body, err := download.Download(testctx, download.NewURLDownload(srv.URL+"/bytes/65536"))
 	require.Nil(t, err)
 	defer body.Close()
 	b, err := ioutil.ReadAll(body)
@@ -113,7 +118,7 @@ func TestDownload_bodyClosesWithoutError(t *testing.T) {
 	srv := httptest.NewServer(httpbin.GetMux())
 	defer srv.Close()
 
-	_, body, err := download.Download(download.NewURLDownload(srv.URL + "/get"))
+	_, body, err := download.Download(testctx, download.NewURLDownload(srv.URL+"/get"))
 	require.Nil(t, err)
 	require.Nil(t, body.Close(), "body should close fine")
 }

--- a/pkg/download/retry.go
+++ b/pkg/download/retry.go
@@ -36,7 +36,7 @@ func WithRetries(ctx *log.Context, downloaders []Downloader, sf SleepFunc) (io.R
 	for _, d := range downloaders {
 		for n := 0; n < expRetryN; n++ {
 			ctx := ctx.With("retry", n)
-			status, out, err := Download(d)
+			status, out, err := Download(ctx, d)
 			if err == nil {
 				return out, nil
 			}

--- a/pkg/download/retry_test.go
+++ b/pkg/download/retry_test.go
@@ -63,7 +63,8 @@ func TestWithRetries_failingBadStatusCode_validateSleeps(t *testing.T) {
 
 	sr := new(sleepRecorder)
 	_, err := download.WithRetries(nopLog(), []download.Downloader{d}, sr.Sleep)
-	require.EqualError(t, err, "unexpected status code: actual=429 expected=200")
+	require.Contains(t, err.Error(), "429 Too Many Requests")
+	require.Contains(t, err.Error(), "Please verify the machine has network connectivity")
 
 	require.Equal(t, sleepSchedule, []time.Duration(*sr))
 }

--- a/pkg/download/retry_test.go
+++ b/pkg/download/retry_test.go
@@ -1,13 +1,13 @@
 package download_test
 
 import (
-	"github.com/Azure/azure-extension-foundation/msi"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-extension-foundation/msi"
 	"github.com/Azure/custom-script-extension-linux/pkg/download"
 	"github.com/ahmetalpbalkan/go-httpbin"
 	"github.com/go-kit/kit/log"
@@ -128,7 +128,8 @@ type mockDownloader struct {
 
 func (self *mockDownloader) GetRequest() (*http.Request, error) {
 	self.timesCalled++
-	return http.NewRequest("GET", self.url, nil)
+	req, err := http.NewRequest("GET", self.url, nil)
+	return req, err
 }
 
 // sleepRecorder keeps track of the durations of Sleep calls

--- a/pkg/download/url.go
+++ b/pkg/download/url.go
@@ -2,6 +2,13 @@ package download
 
 import (
 	"net/http"
+
+	"github.com/google/uuid"
+)
+
+const (
+	xMsClientRequestIdHeaderName  = "x-ms-client-request-id"
+	xMsServiceRequestIdHeaderName = "x-ms-request-id"
 )
 
 // urlDownload describes a URL to download.
@@ -16,5 +23,9 @@ func NewURLDownload(url string) Downloader {
 
 // GetRequest returns a new request to download the URL
 func (u urlDownload) GetRequest() (*http.Request, error) {
-	return http.NewRequest("GET", u.url, nil)
+	req, err := http.NewRequest("GET", u.url, nil)
+	if req != nil {
+		req.Header.Add(xMsClientRequestIdHeaderName, uuid.New().String())
+	}
+	return req, err
 }


### PR DESCRIPTION
For [Error Improvements in VM Extensions](https://microsoft.sharepoint.com/:w:/t/ComputeVM/ERQYqh3QTktFrdtAgBMZvAgBLKT8DqKH3K0rKznDVCr11A?e=bJE1Zm) , when downloading scripts we will log the request ID, response ID, and response code (if provided) and give specific error messages for status codes 401, 404, 400, 500.