### PR TITLE
Include the entire read response body and file save operation inside retry method

### DIFF
--- a/pkg/download/retry.go
+++ b/pkg/download/retry.go
@@ -47,7 +47,7 @@ func WithRetries(ctx *log.Context, f *File, downloaders []Downloader, sf SleepFu
 				// we have a response body, copy it to the file
 				nBytes, err := io.CopyBuffer(f, out, make([]byte, writeBufSize))
 				if err == nil {
-					// we are done, close the response body
+					// we are done, close the response body, log time taken to download the file
 					// and return the number of bytes written
 					out.Close()
 					end = time.Since(start)
@@ -64,6 +64,9 @@ func WithRetries(ctx *log.Context, f *File, downloaders []Downloader, sf SleepFu
 				}
 			}
 
+			// we are here because either server returned a non-200 status code
+			// or we failed to download the response body and write it to file
+			// log the error, time elapsed, bytes downloaded, and close the response body
 			end = time.Since(start)
 			ctx.Log("error", fmt.Sprintf("file download failed with error '%s' : downloaded %d bytes in %d milliseconds", err, nBytes, end.Milliseconds())
 

--- a/pkg/download/retry.go
+++ b/pkg/download/retry.go
@@ -54,6 +54,8 @@ func WithRetries(ctx *log.Context, f *File, downloaders []Downloader, sf SleepFu
 					// because either connection was closed prematurely or file write operation failed
 					// mark status as -1 so that we retry
 					status = -1 
+					// clear out the contents of the file so as to not leave a partial file
+					f.Truncate(0)
 				}
 			}
 

--- a/pkg/download/retry_test.go
+++ b/pkg/download/retry_test.go
@@ -1,8 +1,12 @@
 package download_test
 
 import (
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -33,7 +37,7 @@ func TestActualSleep_actuallySleeps(t *testing.T) {
 }
 
 func TestWithRetries_noRetries(t *testing.T) {
-	dir, file = CreateTestFile()
+	dir, file := CreateTestFile()
 	defer file.Close()
 	defer os.RemoveAll(dir)
 
@@ -50,7 +54,7 @@ func TestWithRetries_noRetries(t *testing.T) {
 }
 
 func TestWithRetries_failing_validateNumberOfCalls(t *testing.T) {
-	dir, file = CreateTestFile()
+	dir, file := CreateTestFile()
 	defer file.Close()
 	defer os.RemoveAll(dir)
 
@@ -67,7 +71,7 @@ func TestWithRetries_failing_validateNumberOfCalls(t *testing.T) {
 }
 
 func TestWithRetries_failingBadStatusCode_validateSleeps(t *testing.T) {
-	dir, file = CreateTestFile()
+	dir, file := CreateTestFile()
 	defer file.Close()
 	defer os.Remove(dir)
 
@@ -85,7 +89,7 @@ func TestWithRetries_failingBadStatusCode_validateSleeps(t *testing.T) {
 }
 
 func TestWithRetries_healingServer(t *testing.T) {
-	dir, file = CreateTestFile()
+	dir, file := CreateTestFile()
 	defer file.Close()
 	defer os.RemoveAll(dir)
 
@@ -102,7 +106,7 @@ func TestWithRetries_healingServer(t *testing.T) {
 }
 
 func TestRetriesWith_SwitchDownloaderOn404(t *testing.T) {
-	dir, file = CreateTestFile()
+	dir, file := CreateTestFile()
 	defer file.Close()
 	defer os.RemoveAll(dir)
 
@@ -122,7 +126,7 @@ func TestRetriesWith_SwitchDownloaderOn404(t *testing.T) {
 }
 
 func TestRetriesWith_SwitchDownloaderThenFailWithCorretErrorMessage(t *testing.T) {
-	dir, file = CreateTestFile()
+	dir, file := CreateTestFile()
 	defer file.Close()
 	defer os.RemoveAll(dir)
 
@@ -139,7 +143,7 @@ func TestRetriesWith_SwitchDownloaderThenFailWithCorretErrorMessage(t *testing.T
 	resp, err := download.WithRetries(nopLog(), file, []download.Downloader{&d404, msiDownloader403}, func(d time.Duration) { return })
 	require.NotNil(t, err, "download with retries should fail")
 	require.Nil(t, resp, "response body should be nil for failed download with retries")
-    require.EqualValues(t, 0, n, "downloaded number of bytes should be zero")
+	require.EqualValues(t, 0, n, "downloaded number of bytes should be zero")
 	require.Equal(t, d404.timesCalled, 1)
 	require.True(t, strings.Contains(err.Error(), download.MsiDownload403ErrorString), "error string doesn't contain the correct message")
 
@@ -155,7 +159,7 @@ func TestRetriesWith_SwitchDownloaderThenFailWithCorretErrorMessage(t *testing.T
 }
 
 func TestRetriesWith_LargeFileThatTimesOutWhileDownloading(t *testing.T) {
-	dir, file = CreateTestFile()
+	dir, file := CreateTestFile()
 	defer file.Close()
 	defer os.RemoveAll(dir)
 
@@ -164,19 +168,19 @@ func TestRetriesWith_LargeFileThatTimesOutWhileDownloading(t *testing.T) {
 	defer srv.Close()
 
 	size := 1024 * 1024 * 256 // 256 MB
-	largeFileDownloader = mockDownloader{0, svr.URL + "/bytes/" + fmt.Sprintf("%d", size)}
+	largeFileDownloader := mockDownloader{0, svr.URL + "/bytes/" + fmt.Sprintf("%d", size)}
 	sr := new(sleepRecorder)
 
-	n, err := download.WitRetries(nopLog(), file, largeFileDownloader, sr.Sleep)
+	n, err := download.WithRetries(nopLog(), file, largeFileDownloader, sr.Sleep)
 	require.NotNil(t, err, "download with retries should fail because of server timeout")
-    require.EqualValues(t, 0, n, "downloaded number of bytes should be zero")
+	require.EqualValues(t, 0, n, "downloaded number of bytes should be zero")
 
 	fi, err := file.Stat()
 	require.Nil(t, err)
 	require.EqualValues(t, 0, fi.Size())
 }
 
-func CreateTestFile() (string, *File){
+func CreateTestFile() (string, *File) {
 	dir, err := ioutil.TempDir("", "")
 	require.Nil(t, err)
 

--- a/pkg/download/save.go
+++ b/pkg/download/save.go
@@ -1,7 +1,6 @@
 package download
 
 import (
-	"io"
 	"os"
 
 	"github.com/go-kit/kit/log"

--- a/pkg/download/save.go
+++ b/pkg/download/save.go
@@ -8,10 +8,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	writeBufSize = 1024 * 8
-)
-
 // SaveTo uses given downloader to fetch the resource with retries and saves the
 // given file. Directory of dst is not created by this function. If a file at
 // dst exists, it will be truncated. If a new file is created, mode is used to
@@ -23,12 +19,10 @@ func SaveTo(ctx *log.Context, d []Downloader, dst string, mode os.FileMode) (int
 	}
 	defer f.Close()
 
-	body, err := WithRetries(ctx, d, ActualSleep)
+	n, err := WithRetries(ctx, f, d, ActualSleep)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to download file")
+		return n, errors.Wrapf(err, "failed to download response and write to file: %s", dst)
 	}
-	defer body.Close()
 
-	n, err := io.CopyBuffer(f, body, make([]byte, writeBufSize))
-	return n, errors.Wrapf(err, "failed to write to file: %s", dst)
+	return n, nil
 }


### PR DESCRIPTION
What operation are we performing on behalf of the customer?
- Downloading the script files and saving them to locla disk

What part of this operation are we retrying on?
- Just the HTTP download and that too only if status is not 200 

What should we be retrying ideally?
- The entire operation  = HTTP request + streaming response + writing streamed bytes to local disk

This PR aims to make all parts of the operation retryable.