### PR TITLE
Removing migrate to mostRecentSeqNum logic

### DIFF
--- a/main/cmds.go
+++ b/main/cmds.go
@@ -77,38 +77,6 @@ func install(ctx *log.Context, h HandlerEnvironment, seqNum int) (string, error)
 	return "", nil
 }
 
-// func migrateToMostRecentSequence(ctx *log.Context, h HandlerEnvironment, seqNum int) {
-// 	// The status folder is used instead of the settings because the settings file is written
-// 	// by the agent before install is called.  As a result, the extension cannot determine if this
-// 	// is a new install or an upgrade.
-// 	//
-// 	// If this is an upgrade there will be a status file. The agent will re-write the last status
-// 	// file to indicate that the upgrade happened successfully. The extension uses the last status
-// 	// sequence number to determine the last settings file that was executed.
-// 	//
-// 	// The agent helpfully copies mrseq every time an extension is upgraded thereby preserving the
-// 	// most recent executed sequence. If extensions use mrseq they benefit from this mechanism, and
-// 	// do not have invent another method.  The CustomScript extension should have been using this
-// 	// from the beginning, but it was not.
-// 	//
-// 	computedSeqNum, err := FindSeqNumStatus(h.HandlerEnvironment.StatusFolder)
-// 	if err != nil {
-// 		// If there was an error, the sequence number is zero.
-// 		ctx.Log("event", "migrate to mrseq", "error", err)
-// 		return
-// 	}
-
-// 	fout, err := os.Create(mostRecentSequence)
-// 	if err != nil {
-// 		ctx.Log("event", "migrate to mrseq", "error", err)
-// 		return
-// 	}
-// 	defer fout.Close()
-
-// 	ctx.Log("event", "migrate to mrseq", "message", fmt.Sprintf("migrated mrseq to %v", computedSeqNum))
-// 	fout.WriteString(fmt.Sprintf("%v", computedSeqNum))
-// }
-
 func uninstall(ctx *log.Context, h HandlerEnvironment, seqNum int) (string, error) {
 	{ // a new context scope with path
 		ctx = ctx.With("path", dataDir)

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -68,49 +68,46 @@ func install(ctx *log.Context, h HandlerEnvironment, seqNum int) (string, error)
 	// If the file mrseq does not exists it is for two possible reasons.
 	//  1. The extension has never been installed on this VMs before
 	//  2. The extension is upgraded from < v2.0.5, which did not use mrseq
+	//  3. The mrseq file was lost during upgrade scenario.
 	//
-	// If it is (2) attempt to migrate to mrseq.  Find the latest settings
-	// file, and set the sequence to it.
-	if _, err := os.Stat(mostRecentSequence); os.IsNotExist(err) {
-		migrateToMostRecentSequence(ctx, h, seqNum)
-	}
+	// To ensure that scripts run, we will not set mrseq during install, only during enable.
 
 	ctx.Log("event", "created data dir", "path", dataDir)
 	ctx.Log("event", "installed")
 	return "", nil
 }
 
-func migrateToMostRecentSequence(ctx *log.Context, h HandlerEnvironment, seqNum int) {
-	// The status folder is used instead of the settings because the settings file is written
-	// by the agent before install is called.  As a result, the extension cannot determine if this
-	// is a new install or an upgrade.
-	//
-	// If this is an upgrade there will be a status file. The agent will re-write the last status
-	// file to indicate that the upgrade happened successfully. The extension uses the last status
-	// sequence number to determine the last settings file that was executed.
-	//
-	// The agent helpfully copies mrseq every time an extension is upgraded thereby preserving the
-	// most recent executed sequence. If extensions use mrseq they benefit from this mechanism, and
-	// do not have invent another method.  The CustomScript extension should have been using this
-	// from the beginning, but it was not.
-	//
-	computedSeqNum, err := FindSeqNumStatus(h.HandlerEnvironment.StatusFolder)
-	if err != nil {
-		// If there was an error, the sequence number is zero.
-		ctx.Log("event", "migrate to mrseq", "error", err)
-		return
-	}
+// func migrateToMostRecentSequence(ctx *log.Context, h HandlerEnvironment, seqNum int) {
+// 	// The status folder is used instead of the settings because the settings file is written
+// 	// by the agent before install is called.  As a result, the extension cannot determine if this
+// 	// is a new install or an upgrade.
+// 	//
+// 	// If this is an upgrade there will be a status file. The agent will re-write the last status
+// 	// file to indicate that the upgrade happened successfully. The extension uses the last status
+// 	// sequence number to determine the last settings file that was executed.
+// 	//
+// 	// The agent helpfully copies mrseq every time an extension is upgraded thereby preserving the
+// 	// most recent executed sequence. If extensions use mrseq they benefit from this mechanism, and
+// 	// do not have invent another method.  The CustomScript extension should have been using this
+// 	// from the beginning, but it was not.
+// 	//
+// 	computedSeqNum, err := FindSeqNumStatus(h.HandlerEnvironment.StatusFolder)
+// 	if err != nil {
+// 		// If there was an error, the sequence number is zero.
+// 		ctx.Log("event", "migrate to mrseq", "error", err)
+// 		return
+// 	}
 
-	fout, err := os.Create(mostRecentSequence)
-	if err != nil {
-		ctx.Log("event", "migrate to mrseq", "error", err)
-		return
-	}
-	defer fout.Close()
+// 	fout, err := os.Create(mostRecentSequence)
+// 	if err != nil {
+// 		ctx.Log("event", "migrate to mrseq", "error", err)
+// 		return
+// 	}
+// 	defer fout.Close()
 
-	ctx.Log("event", "migrate to mrseq", "message", fmt.Sprintf("migrated mrseq to %v", computedSeqNum))
-	fout.WriteString(fmt.Sprintf("%v", computedSeqNum))
-}
+// 	ctx.Log("event", "migrate to mrseq", "message", fmt.Sprintf("migrated mrseq to %v", computedSeqNum))
+// 	fout.WriteString(fmt.Sprintf("%v", computedSeqNum))
+// }
 
 func uninstall(ctx *log.Context, h HandlerEnvironment, seqNum int) (string, error) {
 	{ // a new context scope with path


### PR DESCRIPTION
By removing this logic: 
- Upgrades that do not have mrseq file present will cause the currentSeqNum to run. 
- Upgrades that do have mrseq file present will honor the number in the mrseq file and only execute if mrseqNum less than the currentSeqNum.
- If it is the first ever install, the script will also run since there is no mrseq file to compare currentSeqNum to. 