### PR TITLE
Adds check for ewc not nil

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -80,7 +80,7 @@ func main() {
 	// execute the subcommand
 	reportStatus(ctx, hEnv, seqNum, StatusTransitioning, cmd, "")
 	msg, ewc := cmd.f(ctx, hEnv, seqNum)
-	if ewc.Err != nil {
+	if ewc != nil && ewc.Err != nil {
 		ctx.Log("event", "failed to handle", "error", ewc.Error())
 		ewc.Err = errors.Wrap(ewc.Err, ewc.Error()+msg)
 		reportErrorStatus(ctx, hEnv, seqNum, StatusError, cmd, ewc)


### PR DESCRIPTION
This fix is for the below error found during testing: 

[stderr]
Running scope as unit: install_171650ff-ac82-4493-a4cf-39985bcca58c.scope
'.
    
'Install handler failed for the extension. More information on troubleshooting is available at https://aka.ms/vmextensionlinuxtroubleshoot'
Code: VMExtensionHandlerNonTransientError
Message: The handler for VM extension type 'Microsoft.Azure.Extensions.Edp.CustomScript' has reported terminal failure for VM extension 'CustomScript' with error message: '[ExtensionOperationError] Non-zero exit code: 2, /var/lib/waagent/Microsoft.Azure.Extensions.Edp.CustomScript-2.5.0/bin/custom-script-shim install
[stdout]
Placing logs in directory /var/log/azure/Microsoft.Azure.Extensions.Edp.CustomScript
+ /var/lib/waagent/Microsoft.Azure.Extensions.Edp.CustomScript-2.5.0/bin/custom-script-extension install
time=2026-04-15T20:06:17Z version=v2.1.18/git@- operation=install seq=2 event=start
time=2026-04-15T20:06:17Z version=v2.1.18/git@- operation=install seq=2 status="not reported for operation (by design)"
time=2026-04-15T20:06:17Z version=v2.1.18/git@- operation=install seq=2 event="created data dir" path=/var/lib/waagent/custom-script
time=2026-04-15T20:06:17Z version=v2.1.18/git@- operation=install seq=2 event=installed
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x7c104f]

**goroutine 1 [running]:
main.main()
        /__w/1/s/src/cselinux/test/main/main.go:83 +0x114f**