### PR TITLE
Avoid logging duplicate error messages + fix decryption error 

### DIFF
--- a/main/handlersettingscommon.go
+++ b/main/handlersettingscommon.go
@@ -126,7 +126,7 @@ func unmarshalProtectedSettings(configFolder string, hs handlerSettingsCommon, v
 	// other extension handlers depend on this package for parsing handler
 	// settings.
 
-	//using cms command to support for FIPS 140-3
+	// using cms command to support for FIPS 140-3
 	cmd := exec.Command("openssl", "cms", "-inform", "DER", "-decrypt", "-recip", crt, "-inkey", prv)
 	var bOut, bErr bytes.Buffer
 	var errMsg error
@@ -134,9 +134,9 @@ func unmarshalProtectedSettings(configFolder string, hs handlerSettingsCommon, v
 	cmd.Stdout = &bOut
 	cmd.Stderr = &bErr
 
-	//back up smime command in case cms fails
+	// fall back to smime command in case cms fails
 	if err := cmd.Run(); err != nil {
-		errMsg = fmt.Errorf("decrypting protected settings with cms command failed: error=%v stderr=%s \n now decrypting with smime command", err, bErr.String())
+		errMsg = fmt.Errorf("\ndecrypting protected settings with cms command failed: error=%v stderr=%s", err, bErr.String())
 		cmd = exec.Command("openssl", "smime", "-inform", "DER", "-decrypt", "-recip", crt, "-inkey", prv)
 		cmd.Stdin = bytes.NewReader(decoded)
 		bOut.Reset()
@@ -144,7 +144,7 @@ func unmarshalProtectedSettings(configFolder string, hs handlerSettingsCommon, v
 		cmd.Stdout = &bOut
 		cmd.Stderr = &bErr
 		if err := cmd.Run(); err != nil {
-			return errors.Wrapf(errMsg, "decrypting protected settings with smime command failed: error=%v stderr=%s", err, bErr.String())
+			return fmt.Errorf("%v\ndecrypting protected settings with smime command failed: error=%v stderr=%s", errMsg, err, bErr.String())
 		}
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -82,7 +82,9 @@ func main() {
 	msg, ewc := cmd.f(ctx, hEnv, seqNum)
 	if ewc != nil && ewc.Err != nil {
 		ctx.Log("event", "failed to handle", "error", ewc.Error())
-		ewc.Err = errors.Wrap(ewc.Err, ewc.Error()+msg)
+		if msg != "" {
+			ewc.Err = errors.Wrap(ewc.Err, msg)
+		}
 		reportErrorStatus(ctx, hEnv, seqNum, StatusError, cmd, ewc)
 		os.Exit(cmd.failExitCode)
 	}


### PR DESCRIPTION
### **Error messages are getting duplicated creating clunky messages like:** 

VMExtensionProvisioningError: VM has reported a failure when processing extension 'CustomScriptExtensions' (publisher 'Microsoft.Azure.Extensions' and type 'CustomScript'). This is a system error message: 'failed to get configuration: error reading extension configuration: failed to parse protected settings: decrypting protected settings with smime command failed: error=exit status 2 stderr=Could not open file or uri for loading recipient certificate file from /var/lib/waagent/BDDD8237B086419D48CCEB4A7D6028F239E3728C.crt: No such file or directory
: decrypting protected settings with cms command failed: error=exit status 2 stderr=Could not open file or uri for loading recipient certificate file from /var/lib/waagent/BDDD8237B086419D48CCEB4A7D6028F239E3728C.crt: No such file or directory
 
 now decrypting with smime command: failed to get configuration: error reading extension configuration: failed to parse protected settings: decrypting protected settings with smime command failed: error=exit status 2 stderr=Could not open file or uri for loading recipient certificate file from /var/lib/waagent/BDDD8237B086419D48CCEB4A7D6028F239E3728C.crt: No such file or directory
: decrypting protected settings with cms command failed: error=exit status 2 stderr=Could not open file or uri for loading recipient certificate file from /var/lib/waagent/BDDD8237B086419D48CCEB4A7D6028F239E3728C.crt: No such file or directory
 
 now decrypting with smime command'. Detailed error: ''.
InternalDetail: -21

### **This PR would clean up the message to be :** 

VMExtensionProvisioningError: VM has reported a failure when processing extension 'CustomScriptExtensions' (publisher 'Microsoft.Azure.Extensions' and type 'CustomScript'). This is a system error message: 'failed to get configuration: error reading extension configuration: failed to parse protected settings: 

decrypting protected settings with cms command failed: error=exit status 2 stderr=Could not open file or uri for loading recipient certificate file from /var/lib/waagent/BDDD8237B086419D48CCEB4A7D6028F239E3728C.crt: No such file or directory

decrypting protected settings with smime command failed: error=exit status 2 stderr=Could not open file or uri for loading recipient certificate file from /var/lib/waagent/BDDD8237B086419D48CCEB4A7D6028F239E3728C.crt: No such file or directory'. Detailed error: ''.
InternalDetail: -21



 
